### PR TITLE
After a fresh git clone, the PaRSEC submodule would track master rather than the validated SHA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ if(NOT TARGET PaRSEC::parsec AND NOT TARGET PaRSEC::parsec_ptgpp)
       option(GIT_SUBMODULE "Check submodules during build" ON)
       if(GIT_SUBMODULE)
         message(STATUS "Submodule update")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --force --init --recursive --remote
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --force --init --recursive
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         RESULT_VARIABLE GIT_SUBMOD_RESULT)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")


### PR DESCRIPTION
After a fresh git clone, the PaRSEC submodule would track master rather than the validated SHA
