### PR TITLE
config: macosx: bison 3 is needed, and Veclib doesn't have LAPACKE

### DIFF
--- a/contrib/platforms/macosx
+++ b/contrib/platforms/macosx
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+cat <<'EOF'
+Note about BLAS on Mac OS X:
+============================
+Apple Veclib does not contain LAPACKE, you have to either compile your
+own LAPACKE library that links with Apple Veclib -- or -- simpler
+use OpenBLAS (e.g., from `brew`).
+The performance hit of using OpenBLAS on M1 Mac is significant though,
+for this reason the Apple VecLib remains the default option.
+============================
+EOF
 with_blas=Apple
 
 # if icc/CLang is not set, detect the matching gcc/gfortran pair
@@ -25,11 +35,19 @@ if [ -d /usr/local/opt/openblas/lib ]; then
   ENVVARS+=" LDFLAGS+=' -L/usr/local/opt/openblas/lib'"
 fi
 
-# Per-user personalizations
-if [ "x$USER" == "xbosilca" ]; then
-    with_hwloc=${HWLOC_ROOT:=/Users/bosilca/opt}
-    #with_cuda=${CUDA_ROOT:=/Developer/NVIDIA/CUDA-9.1/}
-    with_ayudame=${AYUDAME_ROOT:="/Users/bosilca/opt/temanejo"}
+# OS-X 12.2 provides Bison 2.3, we need Bison 3 or better
+# Try to get the 'brew' Bison if installed
+if [ -d /usr/local/opt/bison ]; then
+  ENVVARS+=" BISON_ROOT=${BISON_ROOT:-/usr/local/opt/bison}"
 fi
+# Try to get the 'MacPort' Bison if installed
+if [ -x /opt/local/bin/bison ]; then
+  ENVVARS+=" BISON_ROOT=${BISON_ROOT:-/opt/local}"
+fi
+# Try to get the 'Fink' Bison if installed
+if [ -x /sw/bin/bison ]; then
+  ENVVARS+=" BISON_ROOT=${BISON_ROOT:-/sw}"
+fi
+# If Bison still not found, please set BISON_ROOT by hand
 
 


### PR DESCRIPTION
config: macosx: bison 3 is needed, and Veclib doesn't have LAPACKE
Change defaults so that we try to pick Brew options

- [x] Using OpenBLAS on M1 is too costly: automate compiling our own LAPACKE?

Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>