### PR TITLE
Dplasma warming run

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(DplasmaCompilerFlags)
 if(NOT TARGET dplasma_tests_common)
   add_library(dplasma_tests_common OBJECT common.c)
+  set_target_properties(dplasma_tests_common PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
   target_include_directories(dplasma_tests_common
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/RulesTestings.cmake
+++ b/tests/RulesTestings.cmake
@@ -30,6 +30,7 @@ function(testings_addexec OUTPUTLIST PRECISIONS)
                             PRIVATE dplasma_tests_common
                             PUBLIC dplasma
                             $<$<BOOL:${MPI_C_FOUND}>:MPI::MPI_C>)
+      set_target_properties(${exec} PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
     endif(NOT TARGET ${exec})
 
     if( CMAKE_Fortran_COMPILER_WORKS )

--- a/tests/common.c
+++ b/tests/common.c
@@ -273,7 +273,7 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
     /* Default seed */
     iparam[IPARAM_RANDOM_SEED] = 3872;
     iparam[IPARAM_MATRIX_INIT] = dplasmaMatrixRandom;
-    iparam[IPARAM_NRUNS] = 1;
+    iparam[IPARAM_NRUNS] = 3;
 
     do {
 #if defined(PARSEC_HAVE_GETOPT_LONG)
@@ -443,14 +443,18 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
     if(0 == iparam[IPARAM_N] && optind < argc) {
         iparam[IPARAM_N] = atoi(argv[optind++]);
     }
+
+    /* If we ask for check (-x), then we do '0' run, i.e. only the 'warmup'
+     * run, which is sometimes used to initialize the data and do the initial
+     * computation */
+    if(iparam[IPARAM_CHECK]) {
+        iparam[IPARAM_NRUNS] = 0;
+    }
     (void)rc;
 }
 
 static void parse_arguments(int *iparam) {
     int verbose = iparam[IPARAM_RANK] ? 0 : iparam[IPARAM_VERBOSE];
-
-    /* we want to run at least once, right? */
-    if(iparam[IPARAM_NRUNS] < 1) iparam[IPARAM_NRUNS] = 1;
 
     if(iparam[IPARAM_NGPUS] < 0) iparam[IPARAM_NGPUS] = 0;
     if(iparam[IPARAM_NGPUS] > 0) {

--- a/tests/common.h
+++ b/tests/common.h
@@ -133,15 +133,18 @@ void iparam_default_ibnbmb(int* iparam, int ib, int nb, int mb);
 
 /* Define a double type which not pass through the precision generation process */
 typedef double DagDouble_t;
-#define PASTE_CODE_FLOPS( FORMULA, PARAMS ) \
-  double gflops = -1.0, flops = FORMULA PARAMS;
+#define PASTE_CODE_FLOPS( FORMULA, PARAMS )                             \
+  double gflops = -1.0, flops = FORMULA PARAMS;                         \
+  double gflops_avg = 0.0;
 
 #if defined(PRECISION_z) || defined(PRECISION_c)
-#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS) \
-  double gflops = -1.0, flops = (2. * FADD PARAMS + 6. * FMUL PARAMS);
+#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS)                        \
+  double gflops = -1.0, flops = (2. * FADD PARAMS + 6. * FMUL PARAMS);  \
+  double gflops_avg = 0.0;
 #else
-#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS) \
-  double gflops = -1.0, flops = (FADD PARAMS + FMUL PARAMS);
+#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS)                        \
+  double gflops = -1.0, flops = (FADD PARAMS + FMUL PARAMS);            \
+  double gflops_avg = 0.0;
 #endif
 
 /*******************************
@@ -230,26 +233,20 @@ static inline int min(int a, int b) { return a < b ? a : b; }
     PROFILING_SAVE_iINFO("PARAM_BUT_LEVEL", iparam[IPARAM_BUT_LEVEL]);  \
     PROFILING_SAVE_iINFO("PARAM_SCHEDULER", iparam[IPARAM_SCHEDULER]);  
 
-#define PASTE_CODE_PROGRESS_KERNEL(PARSEC, KERNEL)                      \
+#define PASTE_CODE_PROGRESS_KERNEL(PARSEC, KERNEL, ITERATION)           \
     SYNC_TIME_START();                                                  \
     PARSEC_CHECK_ERROR(parsec_context_start(PARSEC), "parsec_context_start"); \
     TIME_START();                                                       \
     PARSEC_CHECK_ERROR(parsec_context_wait(PARSEC), "parsec_context_wait"); \
-    SYNC_TIME_PRINT(rank, (#KERNEL "\tPxQxg= %3d %-3d %d NB= %4d N= %7d : %14f gflops\n", \
-                           P, Q, gpus, NB, N,                           \
-                           gflops=(flops/1e9)/sync_time_elapsed));      \
-    PASTE_PROF_INFO;                                                    \
-    if(loud >= 5 && rank == 0) {                                        \
-        printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n" \
-               "                 encoding=\"none\" compression=\"none\">\n" \
-               "%g\n"                                                   \
-               "</DartMeasurement>\n",                                  \
-               gflops);                                                 \
-    }                                                                   \
-    (void)gflops;
+    if( (ITERATION) > 0) {                                              \
+        SYNC_TIME_PRINT(rank, (#KERNEL "\tPxQxg= %3d %-3d %d NB= %4d N= %7d : %14f gflops\n", \
+                        P, Q, gpus, NB, N,                              \
+                        gflops=(flops/1e9)/sync_time_elapsed));         \
+        gflops_avg += gflops/nruns;                                     \
+    }
 
 
-#define PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(PARSEC, KERNEL, PARAMS, DESTRUCT)\
+#define PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(PARSEC, KERNEL, PARAMS, DESTRUCT, ITERATION)\
     SYNC_TIME_START();                                                  \
     parsec_taskpool_t* PARSEC_##KERNEL = dplasma_##KERNEL##_New PARAMS; \
     PARSEC_CHECK_ERROR(parsec_context_add_taskpool(PARSEC, PARSEC_##KERNEL), "parsec_context_add_taskpool");\
@@ -265,7 +262,7 @@ static inline int min(int a, int b) { return a < b ? a : b; }
     DESTRUCT;                                                           \
     SYNC_TIME_STOP();                                                   \
     double stime_C = sync_time_elapsed;                                 \
-    if(rank==0){                                                        \
+    if(rank==0 && (ITERATION) > 0) {                                    \
         printf("[****] TIME(s) %12.5f : " #KERNEL "\tPxQxg= %3d %-3d %d NB= %4d N= %7d : %14f gflops"\
                   " - ENQ&PROG&DEST %12.5f : %14f gflops"               \
                   " - ENQ %12.5f - DEST %12.5f\n",                      \
@@ -274,15 +271,19 @@ static inline int min(int a, int b) { return a < b ? a : b; }
                           (stime_A+stime_B+stime_C),                    \
                           (flops/1e9)/(stime_A+stime_B+stime_C),        \
                           stime_A,stime_C);                             \
+        gflops_avg += gflops/nruns;                                     \
     }                                                                   \
+    (void)gflops;
+
+#define PASTE_CODE_PERF_LOOP_DONE()  do {                               \
     PASTE_PROF_INFO;                                                    \
-    if(loud >= 5 && rank == 0) {                                        \
+    if(loud >= 5 && rank == 0 && nruns>0) {                             \
         printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n" \
                "                 encoding=\"none\" compression=\"none\">\n" \
                "%g\n"                                                   \
                "</DartMeasurement>\n",                                  \
-               gflops);                                                 \
+               gflops_avg);                                             \
     }                                                                   \
-    (void)gflops;
+} while(0)
 
 #endif /* _TESTSCOMMON_H */

--- a/tests/testing_zgelqf.c
+++ b/tests/testing_zgelqf.c
@@ -52,7 +52,7 @@ int main(int argc, char ** argv)
                                MT*IB, N, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 3) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -61,32 +61,23 @@ int main(int argc, char ** argv)
 
         parsec_devices_release_memory();
 
-        if(iparam[IPARAM_HNB] != iparam[IPARAM_NB])
-        {
-            SYNC_TIME_START();
-            parsec_taskpool_t* PARSEC_zgelqf = dplasma_zgelqf_New( (parsec_tiled_matrix_t*)&dcA,
-                                                                   (parsec_tiled_matrix_t*)&dcT );
-            /* Set the recursive size */
-            //TODO: import recursive from QRF
-            //dplasma_zgelqf_setrecursive( PARSEC_zgelqf, iparam[IPARAM_HNB] );
-            parsec_context_add_taskpool(parsec, PARSEC_zgelqf);
-            if( loud > 2 ) SYNC_TIME_PRINT(rank, ( "zgelqf\tDAG created\n"));
+        SYNC_TIME_START();
+        parsec_taskpool_t* PARSEC_zgelqf = dplasma_zgelqf_New( (parsec_tiled_matrix_t*)&dcA,
+                                                               (parsec_tiled_matrix_t*)&dcT );
 
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zgelqf);
-            dplasma_zgelqf_Destruct( PARSEC_zgelqf );
+        /* TODO: Set the recursive size if iparam[IPARAM_HNB] != iparam[IPARAM_NB]) */
+        //dplasma_zgelqf_setrecursive( PARSEC_zgelqf, iparam[IPARAM_HNB] );
+        parsec_context_add_taskpool(parsec, PARSEC_zgelqf);
+        if( loud > 2 && t > 0) SYNC_TIME_PRINT(rank, ( "zgelqf\tDAG created\n"));
 
-            parsec_taskpool_sync_ids(); /* recursive DAGs are not synchronous on ids */
-        }
-        else
-        {
-            PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgelqf,
-                                      ((parsec_tiled_matrix_t*)&dcA,
-                                      (parsec_tiled_matrix_t*)&dcT),
-                                      dplasma_zgelqf_Destruct( PARSEC_zgelqf ));
-        }
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgelqf, t);
+        dplasma_zgelqf_Destruct( PARSEC_zgelqf );
+
+        parsec_taskpool_sync_ids(); /* recursive DAGs are not synchronous on ids */
+
         parsec_devices_reset_load(parsec);
-
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
 #if defined(PARSEC_SIM)
     {

--- a/tests/testing_zgelqf_hqr.c
+++ b/tests/testing_zgelqf_hqr.c
@@ -81,59 +81,59 @@ int main(int argc, char ** argv)
                                rank, MB, NB, LDB, NRHS, 0, 0,
                                N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
 
-    /* matrix generation */
-    if(loud > 3) printf("+++ Generate matrices ... ");
-    dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
-    if( check )
-        dplasma_zlacpy( parsec, dplasmaUpperLower,
-                        (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
-    if(loud > 3) printf("Done\n");
+    for(int t = 0; t < nruns+1; t++) {
+        if(loud > 3) printf("+++ Generate matrices ... ");
+        dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
+        if(t == 0 && check)
+            dplasma_zlacpy( parsec, dplasmaUpperLower,
+                            (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
+        if(loud > 3) printf("Done\n");
 
-    dplasma_hqr_init( &qrtree,
-                      dplasmaConjTrans, (parsec_tiled_matrix_t *)&dcA,
-                      iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
-                      iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
-                      iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
+        dplasma_hqr_init( &qrtree,
+                          dplasmaConjTrans, (parsec_tiled_matrix_t *)&dcA,
+                          iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
+                          iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
+                          iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
 
-    /* Create PaRSEC */
-    PASTE_CODE_ENQUEUE_KERNEL(parsec, zgelqf_param,
-                              (&qrtree,
-                               (parsec_tiled_matrix_t*)&dcA,
-                               (parsec_tiled_matrix_t*)&dcTS,
-                               (parsec_tiled_matrix_t*)&dcTT));
+        /* Create PaRSEC */
+        PASTE_CODE_ENQUEUE_KERNEL(parsec, zgelqf_param,
+                                  (&qrtree,
+                                          (parsec_tiled_matrix_t*)&dcA,
+                                          (parsec_tiled_matrix_t*)&dcTS,
+                                          (parsec_tiled_matrix_t*)&dcTT));
 
-    /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
-    SYNC_TIME_START();
-    parsec_context_start(parsec);
-    TIME_START();
-    parsec_context_wait(parsec);
+        /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
+        SYNC_TIME_START();
+        parsec_context_start(parsec);
+        TIME_START();
+        parsec_context_wait(parsec);
 
-    SYNC_TIME_PRINT(rank,
-                    ("zgelqf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
-                     iparam[IPARAM_NNODES],
-                     iparam[IPARAM_NCORES],
-                     iparam[IPARAM_P],
-                     iparam[IPARAM_IB],
-                     iparam[IPARAM_MB],
-                     iparam[IPARAM_NB],
-                     iparam[IPARAM_QR_TS_SZE],
-                     iparam[IPARAM_QR_HLVL_SZE],
-                     iparam[IPARAM_LOWLVL_TREE],
-                     iparam[IPARAM_HIGHLVL_TREE],
-                     iparam[IPARAM_QR_DOMINO],
-                     iparam[IPARAM_QR_TSRR],
-                     iparam[IPARAM_M],
-                     iparam[IPARAM_N],
-                     gflops = (flops/1e9)/(sync_time_elapsed)));
-    if(loud >= 5 && rank == 0) {
-        printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n"
-               "                 encoding=\"none\" compression=\"none\">\n"
-               "%g\n"
-               "</DartMeasurement>\n",
-               gflops);
+        if(t > 0) {
+            SYNC_TIME_PRINT(rank,
+                            ("zgelqf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
+                                    iparam[IPARAM_NNODES],
+                                    iparam[IPARAM_NCORES],
+                                    iparam[IPARAM_P],
+                                    iparam[IPARAM_IB],
+                                    iparam[IPARAM_MB],
+                                    iparam[IPARAM_NB],
+                                    iparam[IPARAM_QR_TS_SZE],
+                                    iparam[IPARAM_QR_HLVL_SZE],
+                                    iparam[IPARAM_LOWLVL_TREE],
+                                    iparam[IPARAM_HIGHLVL_TREE],
+                                    iparam[IPARAM_QR_DOMINO],
+                                    iparam[IPARAM_QR_TSRR],
+                                    iparam[IPARAM_M],
+                                    iparam[IPARAM_N],
+                                    gflops = (flops/1e9)/(sync_time_elapsed)));
+            gflops_avg += gflops/nruns;
+        }
+
+        dplasma_zgelqf_param_Destruct( PARSEC_zgelqf_param );
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
 #if defined(PARSEC_SIM)
     if ( rank == 0 ) {
@@ -151,8 +151,6 @@ int main(int argc, char ** argv)
                parsec_getsimulationdate( parsec ));
     }
 #endif
-
-    dplasma_zgelqf_param_Destruct( PARSEC_zgelqf_param );
 
     if( check ) {
         if (N >= M) {

--- a/tests/testing_zgemm.c
+++ b/tests/testing_zgemm.c
@@ -66,15 +66,15 @@ int main(int argc, char ** argv)
                                    rank, MB, NB, LDB, N, 0, 0,
                                    K, N, P, nodes/P, KP, KQ, IP, JQ));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
-
         int t;
-        for(t = 0; t < nruns; t++) {
+        for(t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
+
             parsec_devices_release_memory();
             /* Create PaRSEC */
             PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgemm,
@@ -83,10 +83,12 @@ int main(int argc, char ** argv)
                                        (parsec_tiled_matrix_t *)&dcB,
                                        beta,
                                        (parsec_tiled_matrix_t *)&dcC),
-                                      dplasma_zgemm_Destruct( PARSEC_zgemm ));
+                                      dplasma_zgemm_Destruct( PARSEC_zgemm ),
+                                      t);
 
             parsec_devices_reset_load(parsec);
         }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);
@@ -152,7 +154,7 @@ int main(int argc, char ** argv)
                                (parsec_tiled_matrix_t *)&dcB,
                                (dplasma_complex64_t)beta,
                                (parsec_tiled_matrix_t *)&dcC),
-                              dplasma_zgemm_Destruct( PARSEC_zgemm ));
+                               dplasma_zgemm_Destruct( PARSEC_zgemm ), 0);
 
                 if(loud) printf("Done\n");
 

--- a/tests/testing_zgeqrf_hqr.c
+++ b/tests/testing_zgeqrf_hqr.c
@@ -81,59 +81,61 @@ int main(int argc, char ** argv)
                                rank, MB, NB, LDB, NRHS, 0, 0,
                                M, NRHS, P, nodes/P, KP, KQ, IP, JQ));
 
-    /* matrix generation */
-    if(loud > 3) printf("+++ Generate matrices ... ");
-    dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
-    if( check )
-        dplasma_zlacpy( parsec, dplasmaUpperLower,
-                        (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
-    if(loud > 3) printf("Done\n");
+    for(int t = 0; t < nruns+1; t++) {
+        /* matrix generation */
+        if(loud > 3) printf("+++ Generate matrices ... ");
+        dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
+        if(0 == t && check) {
+            dplasma_zlacpy( parsec, dplasmaUpperLower,
+                            (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
+        }
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
+        if(loud > 3) printf("Done\n");
 
-    dplasma_hqr_init( &qrtree,
-                      dplasmaNoTrans, (parsec_tiled_matrix_t *)&dcA,
-                      iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
-                      iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
-                      iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
+        dplasma_hqr_init( &qrtree,
+                          dplasmaNoTrans, (parsec_tiled_matrix_t *)&dcA,
+                          iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
+                          iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
+                          iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
 
-    /* Create PaRSEC */
-    PASTE_CODE_ENQUEUE_KERNEL(parsec, zgeqrf_param,
-                              (&qrtree,
-                               (parsec_tiled_matrix_t*)&dcA,
-                               (parsec_tiled_matrix_t*)&dcTS,
-                               (parsec_tiled_matrix_t*)&dcTT));
+        /* Create PaRSEC */
+        PASTE_CODE_ENQUEUE_KERNEL(parsec, zgeqrf_param,
+                                  (&qrtree,
+                                          (parsec_tiled_matrix_t*)&dcA,
+                                          (parsec_tiled_matrix_t*)&dcTS,
+                                          (parsec_tiled_matrix_t*)&dcTT));
 
-    /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
-    SYNC_TIME_START();
-    parsec_context_start(parsec);
-    TIME_START();
-    parsec_context_wait(parsec);
+        /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
+        SYNC_TIME_START();
+        parsec_context_start(parsec);
+        TIME_START();
+        parsec_context_wait(parsec);
 
-    SYNC_TIME_PRINT(rank,
-                    ("zgeqrf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
-                     iparam[IPARAM_NNODES],
-                     iparam[IPARAM_NCORES],
-                     iparam[IPARAM_P],
-                     iparam[IPARAM_IB],
-                     iparam[IPARAM_MB],
-                     iparam[IPARAM_NB],
-                     iparam[IPARAM_QR_TS_SZE],
-                     iparam[IPARAM_QR_HLVL_SZE],
-                     iparam[IPARAM_LOWLVL_TREE],
-                     iparam[IPARAM_HIGHLVL_TREE],
-                     iparam[IPARAM_QR_DOMINO],
-                     iparam[IPARAM_QR_TSRR],
-                     iparam[IPARAM_M],
-                     iparam[IPARAM_N],
-                     gflops = (flops/1e9)/(sync_time_elapsed)));
-    if(loud >= 5 && rank == 0) {
-        printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n"
-               "                 encoding=\"none\" compression=\"none\">\n"
-               "%g\n"
-               "</DartMeasurement>\n",
-               gflops);
+        if(t > 0) {
+            SYNC_TIME_PRINT(rank,
+                            ("zgeqrf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
+                                    iparam[IPARAM_NNODES],
+                                    iparam[IPARAM_NCORES],
+                                    iparam[IPARAM_P],
+                                    iparam[IPARAM_IB],
+                                    iparam[IPARAM_MB],
+                                    iparam[IPARAM_NB],
+                                    iparam[IPARAM_QR_TS_SZE],
+                                    iparam[IPARAM_QR_HLVL_SZE],
+                                    iparam[IPARAM_LOWLVL_TREE],
+                                    iparam[IPARAM_HIGHLVL_TREE],
+                                    iparam[IPARAM_QR_DOMINO],
+                                    iparam[IPARAM_QR_TSRR],
+                                    iparam[IPARAM_M],
+                                    iparam[IPARAM_N],
+                                    gflops = (flops/1e9)/(sync_time_elapsed)));
+            gflops_avg += gflops/nruns;
+        }
+
+        dplasma_zgeqrf_param_Destruct( PARSEC_zgeqrf_param );
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
 #if defined(PARSEC_SIM)
     if ( rank == 0 ) {
@@ -151,8 +153,6 @@ int main(int argc, char ** argv)
                parsec_getsimulationdate( parsec ));
     }
 #endif
-
-    dplasma_zgeqrf_param_Destruct( PARSEC_zgeqrf_param );
 
     if( check ) {
         if (M >= N) {

--- a/tests/testing_zgetrf_1d.c
+++ b/tests/testing_zgetrf_1d.c
@@ -63,7 +63,7 @@ int main(int argc, char ** argv)
                                                       1, dplasma_imin(M, N), P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -77,12 +77,13 @@ int main(int argc, char ** argv)
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_1d,
                           ((parsec_tiled_matrix_t*)&dcA,
                            (parsec_tiled_matrix_t*)&dcIPIV, &info),
-                          dplasma_zgetrf_1d_Destruct( PARSEC_zgetrf_1d ));
+                          dplasma_zgetrf_1d_Destruct( PARSEC_zgetrf_1d ), t);
 
         if(loud > 2) printf("Done.\n");
 
         parsec_devices_reset_load(parsec);
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_incpiv.c
+++ b/tests/testing_zgetrf_incpiv.c
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
                                M, NT, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -75,10 +75,11 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t*)&dcIPIV,
                             &info));
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_incpiv);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_incpiv, t);
         dplasma_zgetrf_incpiv_Destruct( PARSEC_zgetrf_incpiv );
         if(loud > 2) printf("Done.\n");
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_nopiv.c
+++ b/tests/testing_zgetrf_nopiv.c
@@ -52,7 +52,7 @@ int main(int argc, char ** argv)
                                                       M, N, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -65,13 +65,14 @@ int main(int argc, char ** argv)
 
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_nopiv, 
                           ((parsec_tiled_matrix_t*)&dcA, &info),
-                          dplasma_zgetrf_nopiv_Destruct( PARSEC_zgetrf_nopiv ));
+                          dplasma_zgetrf_nopiv_Destruct( PARSEC_zgetrf_nopiv ), t);
 
         if(loud > 2) printf("Done.\n");
 
         parsec_devices_reset_load(parsec);
 
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_ptgpanel.c
+++ b/tests/testing_zgetrf_ptgpanel.c
@@ -58,7 +58,7 @@ int main(int argc, char ** argv)
                                P, dplasma_imin(M, N), P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -72,12 +72,13 @@ int main(int argc, char ** argv)
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_ptgpanel,
                   ((parsec_tiled_matrix_t*)&dcA,
                    (parsec_tiled_matrix_t*)&dcIPIV, &info),
-                  dplasma_zgetrf_ptgpanel_Destruct( PARSEC_zgetrf_ptgpanel ));
+                  dplasma_zgetrf_ptgpanel_Destruct( PARSEC_zgetrf_ptgpanel ), t);
 
         if(loud > 2) printf("Done.\n");
 
         parsec_devices_reset_load(parsec);
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_qrf.c
+++ b/tests/testing_zgetrf_qrf.c
@@ -76,7 +76,7 @@ int main(int argc, char ** argv)
     lu_tab = (int *)malloc( dplasma_imin(MT, NT)*sizeof(int) );
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -104,7 +104,7 @@ int main(int argc, char ** argv)
                          iparam[IPARAM_QR_HLVL_SZE], alpha, lu_tab,
                          &info));
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_qrf);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_qrf, t);
         dplasma_zgetrf_qrf_Destruct( PARSEC_zgetrf_qrf );
         if(loud > 2) printf("Done.\n");
 
@@ -135,6 +135,7 @@ int main(int argc, char ** argv)
             printf("\n");
         }
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zher2k.c
+++ b/tests/testing_zher2k.c
@@ -66,24 +66,27 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
-        dplasma_zplghe( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
+            dplasma_zplghe( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        /* Create PaRSEC */
-        PASTE_CODE_ENQUEUE_KERNEL(parsec, zher2k,
-                                  (uplo, trans,
-                                   alpha, (parsec_tiled_matrix_t *)&dcA,
-                                          (parsec_tiled_matrix_t *)&dcB,
-                                   beta,  (parsec_tiled_matrix_t *)&dcC));
+            /* Create PaRSEC */
+            PASTE_CODE_ENQUEUE_KERNEL(parsec, zher2k,
+                                      (uplo, trans,
+                                              alpha, (parsec_tiled_matrix_t *)&dcA,
+                                              (parsec_tiled_matrix_t *)&dcB,
+                                              beta,  (parsec_tiled_matrix_t *)&dcC));
 
-        /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zher2k);
+            /* lets rock! */
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zher2k, t);
 
-        dplasma_zher2k_Destruct( PARSEC_zher2k );
+            dplasma_zher2k_Destruct( PARSEC_zher2k );
+        }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -116,6 +116,7 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
     dplasma_complex64_t *C;
     parsec_task_t *this_task = gpu_task->ec;
     parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t*)gpu_stream;
+    parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t*)gpu_device;
 
     parsec_dtd_unpack_args(this_task, &transA, &transB, &m, &n, &k, &alpha,
                            &A, &lda, &B, &ldb, &beta, &C, &ldc);
@@ -131,9 +132,9 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
 #if defined(PARSEC_DEBUG_NOISIER)
     {
         char tmp[MAX_TASK_STRLEN];
-        PARSEC_DEBUG_VERBOSE(10, parsec_cuda_output_stream, "GPU[%1d]:\tEnqueue on device %s priority %d",
-                             gpu_device->cuda_index, parsec_task_snprintf(tmp, MAX_TASK_STRLEN,
-                                                                          (parsec_task_t *) this_task),
+        PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, "GPU[%1d]:\tEnqueue on device %s priority %d",
+                             cuda_device->cuda_index, parsec_task_snprintf(tmp, MAX_TASK_STRLEN,
+                                                                           (parsec_task_t *) this_task),
                              this_task->priority);
     }
 #endif /* defined(PARSEC_DEBUG_NOISIER) */

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -15,9 +15,11 @@
 #include "parsec/interfaces/dtd/insert_function.h"
 
 #if defined(PARSEC_HAVE_CUDA)
+
 #include "parsec/parsec_internal.h"
 #include "parsec/mca/device/cuda/device_cuda.h"
 #include <cublas.h>
+
 #endif  /* defined(PARSEC_HAVE_CUDA) */
 
 /* Global index for the full tile datatype */
@@ -43,7 +45,7 @@ parsec_core_trsm(parsec_execution_stream_t *es, parsec_task_t *this_task)
 {
     (void)es;
     int side, uplo, trans, diag;
-    int  m, n, lda, ldc;
+    int m, n, lda, ldc;
     dplasma_complex64_t alpha;
     dplasma_complex64_t *A, *C;
 
@@ -74,7 +76,7 @@ parsec_core_herk(parsec_execution_stream_t *es, parsec_task_t *this_task)
 
     CORE_zherk(uplo, trans, m, n,
                alpha, A, lda,
-               beta,  C, ldc);
+               beta, C, ldc);
 
     return PARSEC_HOOK_RETURN_DONE;
 }
@@ -96,17 +98,18 @@ parsec_core_gemm(parsec_execution_stream_t *es, parsec_task_t *this_task)
     CORE_zgemm(transA, transB,
                m, n, k,
                alpha, A, lda,
-                      B, ldb,
-               beta,  C, ldc);
+               B, ldb,
+               beta, C, ldc);
 
     return PARSEC_HOOK_RETURN_DONE;
 }
 
 #if defined(PARSEC_HAVE_CUDA)
+
 static int
-gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
-                                       parsec_gpu_task_t * gpu_task,
-                                       parsec_gpu_exec_stream_t * gpu_stream)
+gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t *gpu_device,
+                                       parsec_gpu_task_t *gpu_task,
+                                       parsec_gpu_exec_stream_t *gpu_stream)
 {
     int transA, transB;
     int m, n, k, lda, ldb, ldc;
@@ -115,14 +118,14 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
     dplasma_complex64_t *B;
     dplasma_complex64_t *C;
     parsec_task_t *this_task = gpu_task->ec;
-    parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t*)gpu_stream;
-    parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t*)gpu_device;
+    parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t *)gpu_stream;
+    parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t *)gpu_device;
 
     parsec_dtd_unpack_args(this_task, &transA, &transB, &m, &n, &k, &alpha,
                            &A, &lda, &B, &ldb, &beta, &C, &ldc);
 
 #if defined(PRECISION_z) || defined(PRECISION_c)
-    cuDoubleComplex zone  = make_cuDoubleComplex( 1., 0.);
+    cuDoubleComplex zone = make_cuDoubleComplex(1., 0.);
     cuDoubleComplex mzone = make_cuDoubleComplex(-1., 0.);
 #else
     double zone  =  1.;
@@ -134,22 +137,22 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
         char tmp[MAX_TASK_STRLEN];
         PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream, "GPU[%1d]:\tEnqueue on device %s priority %d",
                              cuda_device->cuda_index, parsec_task_snprintf(tmp, MAX_TASK_STRLEN,
-                                                                           (parsec_task_t *) this_task),
+                                                                           (parsec_task_t *)this_task),
                              this_task->priority);
     }
 #endif /* defined(PARSEC_DEBUG_NOISIER) */
 
     cublasStatus_t status;
 
-    cublasSetKernelStream( cuda_stream->cuda_stream );
-    cublasZgemm( 'N', dplasma_lapack_const(dplasmaConjTrans),
-                 n, n, k,
-                 mzone, (cuDoubleComplex*)A, lda,
-                 (cuDoubleComplex*)B, ldb,
-                 zone,  (cuDoubleComplex*)C, ldc );
+    cublasSetKernelStream(cuda_stream->cuda_stream);
+    cublasZgemm('N', dplasma_lapack_const(dplasmaConjTrans),
+                n, n, k,
+                mzone, (cuDoubleComplex *)A, lda,
+                (cuDoubleComplex *)B, ldb,
+                zone, (cuDoubleComplex *)C, ldc);
     status = cublasGetError();
-    PARSEC_CUDA_CHECK_ERROR( "cublasZgemm ", status,
-                             {return -1;} );
+    PARSEC_CUDA_CHECK_ERROR("cublasZgemm ", status,
+                            { return -1; });
     (void)gpu_device;
     return PARSEC_HOOK_RETURN_DONE;
 }
@@ -171,23 +174,23 @@ parsec_core_cuda_gemm(parsec_execution_stream_t *es, parsec_task_t *this_task)
                            &A, &lda, &B, &ldb, &beta, &C, &ldc);
 
     ratio = ((m + 1) - k);
-    dev_index = parsec_get_best_device((parsec_task_t *) this_task, ratio);
+    dev_index = parsec_get_best_device((parsec_task_t *)this_task, ratio);
     assert(dev_index >= 0);
-    if (dev_index < 2) {
+    if( dev_index < 2 ) {
         /* Fallback to the CPU only version */
         return parsec_core_gemm(es, this_task);
     }
 
-    gpu_task = (parsec_gpu_task_t *) calloc(1, sizeof(parsec_gpu_task_t));
+    gpu_task = (parsec_gpu_task_t *)calloc(1, sizeof(parsec_gpu_task_t));
     PARSEC_OBJ_CONSTRUCT(gpu_task, parsec_list_item_t);
-    gpu_task->ec = (parsec_task_t *) this_task;
+    gpu_task->ec = (parsec_task_t *)this_task;
     gpu_task->submit = &gpu_kernel_submit_dpotrf_U_potrf_dgemm;
     gpu_task->task_type = 0;
     gpu_task->load = ratio * parsec_device_sweight[dev_index];
-    gpu_task->last_data_check_epoch = -1;	/* force at least one validation for the task */
+    gpu_task->last_data_check_epoch = -1;    /* force at least one validation for the task */
     gpu_task->pushout = 0;
     gpu_task->flow[0] = NULL; /*&flow_of_dpotrf_U_potrf_dgemm_for_C;*/
-    if ((m == (k + 1))) {
+    if((m == (k + 1))) {
         gpu_task->pushout |= (1 << 0);
     }
     gpu_task->flow[1] = NULL;  /* &flow_of_dpotrf_U_potrf_dgemm_for_A; */
@@ -197,11 +200,12 @@ parsec_core_cuda_gemm(parsec_execution_stream_t *es, parsec_task_t *this_task)
     (void)es;
     return parsec_cuda_kernel_scheduler(es, gpu_task, dev_index);
 }
+
 #endif  /* defined(PARSEC_HAVE_CUDA) */
 
 int main(int argc, char **argv)
 {
-    parsec_context_t* parsec;
+    parsec_context_t *parsec;
     int iparam[IPARAM_SIZEOF];
     int uplo = dplasmaUpper;
     int info = 0;
@@ -222,259 +226,269 @@ int main(int argc, char **argv)
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZPOTRF, ((DagDouble_t)N));
 
+    int nbgpus = 0;
+#if defined(PARSEC_HAVE_CUDA)
+    for(int i = 0; i < (int)parsec_nb_devices; i++) {
+        parsec_device_module_t *dev = parsec_mca_device_get(i);
+        if(dev->type & PARSEC_DEV_CUDA)
+            nbgpus++;
+    }
+#endif
+
     /* initializing matrix structure */
-    LDA = dplasma_imax( LDA, N );
-    LDB = dplasma_imax( LDB, N );
+    LDA = dplasma_imax(LDA, N);
+    LDB = dplasma_imax(LDB, N);
     KP = 1;
     KQ = 1;
 
     PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
-        parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
-                                   rank, MB, NB, LDA, N, 0, 0,
-                                   N, N, P, nodes/P, uplo));
+                               parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
+            rank, MB, NB, LDA, N, 0, 0,
+            N, N, P, nodes / P, uplo));
 
     /* Initializing dc for dtd */
     parsec_matrix_sym_block_cyclic_t *__dcA = &dcA;
     parsec_dtd_data_collection_init((parsec_data_collection_t *)&dcA);
 
-    /* matrix generation */
-    if(loud > 3) printf("+++ Generate matrices ... ");
-    dplasma_zplghe( parsec, (double)(N), uplo,
-                    (parsec_tiled_matrix_t *)&dcA, random_seed);
-    if(loud > 3) printf("Done\n");
 
     /* Getting new parsec handle of dtd type */
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 
     /* Allocating data arrays to be used by comm engine */
     parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
-    dplasma_add2arena_tile( tile_full,
-                            dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
-                            PARSEC_ARENA_ALIGNMENT_SSE,
-                            parsec_datatype_double_complex_t, dcA.super.mb );
+    dplasma_add2arena_tile(tile_full,
+                           dcA.super.mb * dcA.super.nb * sizeof(dplasma_complex64_t),
+                           PARSEC_ARENA_ALIGNMENT_SSE,
+                           parsec_datatype_double_complex_t, dcA.super.mb);
 
-    /* Registering the handle with parsec context */
-    parsec_context_add_taskpool( parsec, dtd_tp );
+    for( int t = 0; t < nruns + 1; t++ ) {
+        /* matrix generation */
+        if( loud > 3 ) printf("+++ Generate matrices ... ");
+        dplasma_zplghe(parsec, (double)(N), uplo,
+                       (parsec_tiled_matrix_t *)&dcA, random_seed);
+        if( loud > 3 ) printf("Done\n");
 
-    SYNC_TIME_START();
+        /* Registering the handle with parsec context */
+        parsec_context_add_taskpool(parsec, dtd_tp);
 
-    /* #### parsec context Starting #### */
+        SYNC_TIME_START();
 
-    /* start parsec context */
-    parsec_context_start( parsec );
+        /* #### parsec context Starting #### */
 
-    /**
-     * To be or not to be: CUDA or plain CPU ?
-     */
+        /* start parsec context */
+        parsec_context_start(parsec);
+
+        /**
+         * To be or not to be: CUDA or plain CPU ?
+         */
 #if defined(PARSEC_HAVE_CUDA)
-    parsec_dtd_funcptr_t* gemm_fct = parsec_core_cuda_gemm;
+        parsec_dtd_funcptr_t *gemm_fct = parsec_core_cuda_gemm;
 #else
-    parsec_dtd_funcptr_t* gemm_fct = parsec_core_gemm;
+        parsec_dtd_funcptr_t* gemm_fct = parsec_core_gemm;
 #endif  /* defined(PARSEC_HAVE_CUDA) */
 
-    if( dplasmaLower == uplo ) {
+        if( dplasmaLower == uplo ) {
 
-        side = dplasmaRight;
-        transA_p = dplasmaConjTrans;
-        diag = dplasmaNonUnit;
-        alpha_trsm = 1.0;
-        trans = dplasmaNoTrans;
-        alpha_herk = -1.0;
-        beta = 1.0;
-        transB = dplasmaConjTrans;
-        transA_g = dplasmaNoTrans;
+            side = dplasmaRight;
+            transA_p = dplasmaConjTrans;
+            diag = dplasmaNonUnit;
+            alpha_trsm = 1.0;
+            trans = dplasmaNoTrans;
+            alpha_herk = -1.0;
+            beta = 1.0;
+            transB = dplasmaConjTrans;
+            transA_g = dplasmaNoTrans;
 
-        total = dcA.super.mt;
-        /* Testing Insert Function */
-        for( k = 0; k < total; k++ ) {
-            tempkm = (k == (dcA.super.mt - 1)) ? dcA.super.m - k * dcA.super.mb : dcA.super.mb;
-            ldak = BLKLDD(&dcA.super, k);
+            total = dcA.super.mt;
+            /* Testing Insert Function */
+            for( k = 0; k < total; k++ ) {
+                tempkm = (k == (dcA.super.mt - 1)) ? dcA.super.m - k * dcA.super.mb : dcA.super.mb;
+                ldak = BLKLDD(&dcA.super, k);
 
-            parsec_dtd_insert_task( dtd_tp, parsec_core_potrf,
-                              (total - k) * (total-k) * (total - k)/*priority*/, PARSEC_DEV_CPU, "Potrf",
-                               sizeof(int),      &uplo,              PARSEC_VALUE,
-                               sizeof(int),      &tempkm,            PARSEC_VALUE,
-                               PASSED_BY_REF,    PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                               sizeof(int),      &ldak,              PARSEC_VALUE,
-                               sizeof(int *),    &info,              PARSEC_SCRATCH,
-                               PARSEC_DTD_ARG_END );
+                parsec_dtd_insert_task(dtd_tp, parsec_core_potrf,
+                                       (total - k) * (total - k) * (total - k)/*priority*/, PARSEC_DEV_CPU, "Potrf",
+                                       sizeof(int), &uplo, PARSEC_VALUE,
+                                       sizeof(int), &tempkm, PARSEC_VALUE,
+                                       PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                       sizeof(int), &ldak, PARSEC_VALUE,
+                                       sizeof(int *), &info, PARSEC_SCRATCH,
+                                       PARSEC_DTD_ARG_END);
 
-            for( m = k+1; m < total; m++ ) {
-                tempmm = m == dcA.super.mt - 1 ? dcA.super.m - m * dcA.super.mb : dcA.super.mb;
-                ldam = BLKLDD(&dcA.super, m);
-                parsec_dtd_insert_task( dtd_tp, parsec_core_trsm,
-                                  (total - m) * (total-m) * (total - m) + 3 * ((2 * total) - k - m - 1) * (m - k)/*priority*/,
-                                  PARSEC_DEV_CPU, "Trsm",
-                                   sizeof(int),      &side,               PARSEC_VALUE,
-                                   sizeof(int),      &uplo,               PARSEC_VALUE,
-                                   sizeof(int),      &transA_p,           PARSEC_VALUE,
-                                   sizeof(int),      &diag,               PARSEC_VALUE,
-                                   sizeof(int),      &tempmm,             PARSEC_VALUE,
-                                   sizeof(int),      &dcA.super.nb,    PARSEC_VALUE,
-                                   sizeof(dplasma_complex64_t),      &alpha_trsm,         PARSEC_VALUE,
-                                   PASSED_BY_REF,    PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INPUT | TILE_FULL,
-                                   sizeof(int),      &ldak,               PARSEC_VALUE,
-                                   PASSED_BY_REF,    PARSEC_DTD_TILE_OF(A, m, k), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                   sizeof(int),      &ldam,               PARSEC_VALUE,
-                                   PARSEC_DTD_ARG_END );
-            }
-            parsec_dtd_data_flush( dtd_tp, PARSEC_DTD_TILE_OF(A, k, k) );
-
-            for( m = k+1; m < dcA.super.nt; m++ ) {
-                tempmm = m == dcA.super.mt - 1 ? dcA.super.m - m * dcA.super.mb : dcA.super.mb;
-                ldam = BLKLDD(&dcA.super, m);
-                parsec_dtd_insert_task( dtd_tp, parsec_core_herk,
-                                  (total - m) * (total - m) * (total - m) + 3 * (m - k)/*priority*/,
-                                  PARSEC_DEV_CPU, "Herk",
-                                   sizeof(int),       &uplo,               PARSEC_VALUE,
-                                   sizeof(int),       &trans,              PARSEC_VALUE,
-                                   sizeof(int),       &tempmm,             PARSEC_VALUE,
-                                   sizeof(int),       &dcA.super.mb,    PARSEC_VALUE,
-                                   sizeof(dplasma_complex64_t),       &alpha_herk,         PARSEC_VALUE,
-                                   PASSED_BY_REF,     PARSEC_DTD_TILE_OF(A, m, k), PARSEC_INPUT | TILE_FULL,
-                                   sizeof(int),       &ldam,               PARSEC_VALUE,
-                                   sizeof(dplasma_complex64_t),       &beta,               PARSEC_VALUE,
-                                   PASSED_BY_REF,     PARSEC_DTD_TILE_OF(A, m, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                   sizeof(int),       &ldam,               PARSEC_VALUE,
-                                   PARSEC_DTD_ARG_END );
-
-                for( n = m+1; n < total; n++ ) {
-                    ldan = BLKLDD(&dcA.super, n);
-                    parsec_dtd_insert_task( dtd_tp,  gemm_fct,
-                                       (total - m) * (total - m) * (total - m) + 3 * ((2 * total) - m - n - 3) * (m - n) + 6 * (m - k) /*priority*/,
-#if defined(PARSEC_HAVE_CUDA)
-                                       PARSEC_DEV_CUDA,
-#else
-                                       PARSEC_DEV_CPU,
-#endif  /* defined(PARSEC_HAVE_CUDA) */
-                                       "Gemm",
-                                       sizeof(int),        &transA_g,           PARSEC_VALUE,
-                                       sizeof(int),        &transB,             PARSEC_VALUE,
-                                       sizeof(int),        &tempmm,             PARSEC_VALUE,
-                                       sizeof(int),        &dcA.super.mb,    PARSEC_VALUE,
-                                       sizeof(int),        &dcA.super.mb,    PARSEC_VALUE,
-                                       sizeof(dplasma_complex64_t),        &alpha_herk,         PARSEC_VALUE,
-                                       PASSED_BY_REF,      PARSEC_DTD_TILE_OF(A, n, k), PARSEC_INPUT | TILE_FULL,
-                                       sizeof(int),        &ldan,               PARSEC_VALUE,
-                                       PASSED_BY_REF,      PARSEC_DTD_TILE_OF(A, m, k), PARSEC_INPUT | TILE_FULL,
-                                       sizeof(int),        &ldam,               PARSEC_VALUE,
-                                       sizeof(dplasma_complex64_t),        &beta,               PARSEC_VALUE,
-                                       PASSED_BY_REF,      PARSEC_DTD_TILE_OF(A, n, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                       sizeof(int),        &ldan,               PARSEC_VALUE,
-                                       PARSEC_DTD_ARG_END );
+                for( m = k + 1; m < total; m++ ) {
+                    tempmm = m == dcA.super.mt - 1 ? dcA.super.m - m * dcA.super.mb : dcA.super.mb;
+                    ldam = BLKLDD(&dcA.super, m);
+                    parsec_dtd_insert_task(dtd_tp, parsec_core_trsm,
+                                           (total - m) * (total - m) * (total - m) + 3 * ((2 * total) - k - m - 1) * (m - k)/*priority*/,
+                                           PARSEC_DEV_CPU, "Trsm",
+                                           sizeof(int), &side, PARSEC_VALUE,
+                                           sizeof(int), &uplo, PARSEC_VALUE,
+                                           sizeof(int), &transA_p, PARSEC_VALUE,
+                                           sizeof(int), &diag, PARSEC_VALUE,
+                                           sizeof(int), &tempmm, PARSEC_VALUE,
+                                           sizeof(int), &dcA.super.nb, PARSEC_VALUE,
+                                           sizeof(dplasma_complex64_t), &alpha_trsm, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INPUT | TILE_FULL,
+                                           sizeof(int), &ldak, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, m, k), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                           sizeof(int), &ldam, PARSEC_VALUE,
+                                           PARSEC_DTD_ARG_END);
                 }
-                parsec_dtd_data_flush( dtd_tp, PARSEC_DTD_TILE_OF(A, m, k) );
+                parsec_dtd_data_flush(dtd_tp, PARSEC_DTD_TILE_OF(A, k, k));
+
+                for( m = k + 1; m < dcA.super.nt; m++ ) {
+                    tempmm = m == dcA.super.mt - 1 ? dcA.super.m - m * dcA.super.mb : dcA.super.mb;
+                    ldam = BLKLDD(&dcA.super, m);
+                    parsec_dtd_insert_task(dtd_tp, parsec_core_herk,
+                                           (total - m) * (total - m) * (total - m) + 3 * (m - k)/*priority*/,
+                                           PARSEC_DEV_CPU, "Herk",
+                                           sizeof(int), &uplo, PARSEC_VALUE,
+                                           sizeof(int), &trans, PARSEC_VALUE,
+                                           sizeof(int), &tempmm, PARSEC_VALUE,
+                                           sizeof(int), &dcA.super.mb, PARSEC_VALUE,
+                                           sizeof(dplasma_complex64_t), &alpha_herk, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, m, k), PARSEC_INPUT | TILE_FULL,
+                                           sizeof(int), &ldam, PARSEC_VALUE,
+                                           sizeof(dplasma_complex64_t), &beta, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, m, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                           sizeof(int), &ldam, PARSEC_VALUE,
+                                           PARSEC_DTD_ARG_END);
+
+                    for( n = m + 1; n < total; n++ ) {
+                        int target_device = nbgpus > 0 ? PARSEC_DEV_CUDA : PARSEC_DEV_CPU;
+                        ldan = BLKLDD(&dcA.super, n);
+                        parsec_dtd_insert_task(dtd_tp, gemm_fct,
+                                               (total - m) * (total - m) * (total - m) + 3 * ((2 * total) - m - n - 3) * (m - n) + 6 * (m - k) /*priority*/,
+                                               target_device,
+                                               "Gemm",
+                                               sizeof(int), &transA_g, PARSEC_VALUE,
+                                               sizeof(int), &transB, PARSEC_VALUE,
+                                               sizeof(int), &tempmm, PARSEC_VALUE,
+                                               sizeof(int), &dcA.super.mb, PARSEC_VALUE,
+                                               sizeof(int), &dcA.super.mb, PARSEC_VALUE,
+                                               sizeof(dplasma_complex64_t), &alpha_herk, PARSEC_VALUE,
+                                               PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, n, k), PARSEC_INPUT | TILE_FULL,
+                                               sizeof(int), &ldan, PARSEC_VALUE,
+                                               PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, m, k), PARSEC_INPUT | TILE_FULL,
+                                               sizeof(int), &ldam, PARSEC_VALUE,
+                                               sizeof(dplasma_complex64_t), &beta, PARSEC_VALUE,
+                                               PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, n, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                               sizeof(int), &ldan, PARSEC_VALUE,
+                                               PARSEC_DTD_ARG_END);
+                    }
+                    parsec_dtd_data_flush(dtd_tp, PARSEC_DTD_TILE_OF(A, m, k));
+                }
+            }
+        } else {
+            side = dplasmaLeft;
+            transA_p = dplasmaConjTrans;
+            diag = dplasmaNonUnit;
+            alpha_trsm = 1.0;
+            trans = dplasmaConjTrans;
+            alpha_herk = -1.0;
+            beta = 1.0;
+            transB = dplasmaNoTrans;
+            transA_g = dplasmaConjTrans;
+
+            total = dcA.super.nt;
+
+            for( k = 0; k < total; k++ ) {
+                tempkm = k == dcA.super.nt - 1 ? dcA.super.n - k * dcA.super.nb : dcA.super.nb;
+                ldak = BLKLDD(&dcA.super, k);
+                parsec_dtd_insert_task(dtd_tp, parsec_core_potrf,
+                                       (total - k) * (total - k) * (total - k)/*priority*/, PARSEC_DEV_CPU, "Potrf",
+                                       sizeof(int), &uplo, PARSEC_VALUE,
+                                       sizeof(int), &tempkm, PARSEC_VALUE,
+                                       PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                       sizeof(int), &ldak, PARSEC_VALUE,
+                                       sizeof(int *), &info, PARSEC_SCRATCH,
+                                       PARSEC_DTD_ARG_END);
+
+                for( m = k + 1; m < total; m++ ) {
+                    tempmm = m == dcA.super.nt - 1 ? dcA.super.n - m * dcA.super.nb : dcA.super.nb;
+                    parsec_dtd_insert_task(dtd_tp, parsec_core_trsm,
+                                           (total - m) * (total - m) * (total - m) + 3 * ((2 * total) - k - m - 1) * (m - k)/*priority*/,
+                                           PARSEC_DEV_CPU, "Trsm",
+                                           sizeof(int), &side, PARSEC_VALUE,
+                                           sizeof(int), &uplo, PARSEC_VALUE,
+                                           sizeof(int), &transA_p, PARSEC_VALUE,
+                                           sizeof(int), &diag, PARSEC_VALUE,
+                                           sizeof(int), &dcA.super.nb, PARSEC_VALUE,
+                                           sizeof(int), &tempmm, PARSEC_VALUE,
+                                           sizeof(dplasma_complex64_t), &alpha_trsm, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INPUT | TILE_FULL,
+                                           sizeof(int), &ldak, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                           sizeof(int), &ldak, PARSEC_VALUE,
+                                           PARSEC_DTD_ARG_END);
+                }
+                parsec_dtd_data_flush(dtd_tp, PARSEC_DTD_TILE_OF(A, k, k));
+
+                for( m = k + 1; m < dcA.super.mt; m++ ) {
+                    tempmm = m == dcA.super.nt - 1 ? dcA.super.n - m * dcA.super.nb : dcA.super.nb;
+                    ldam = BLKLDD(&dcA.super, m);
+                    parsec_dtd_insert_task(dtd_tp, parsec_core_herk,
+                                           (total - m) * (total - m) * (total - m) + 3 * (m - k)/*priority*/,
+                                           PARSEC_DEV_CPU, "Herk",
+                                           sizeof(int), &uplo, PARSEC_VALUE,
+                                           sizeof(int), &trans, PARSEC_VALUE,
+                                           sizeof(int), &tempmm, PARSEC_VALUE,
+                                           sizeof(int), &dcA.super.mb, PARSEC_VALUE,
+                                           sizeof(dplasma_complex64_t), &alpha_herk, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, m), PARSEC_INPUT | TILE_FULL,
+                                           sizeof(int), &ldak, PARSEC_VALUE,
+                                           sizeof(dplasma_complex64_t), &beta, PARSEC_VALUE,
+                                           PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, m, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                           sizeof(int), &ldam, PARSEC_VALUE,
+                                           PARSEC_DTD_ARG_END);
+
+                    for( n = m + 1; n < total; n++ ) {
+                        int target_device = nbgpus > 0 ? PARSEC_DEV_CUDA : PARSEC_DEV_CPU;
+                        ldan = BLKLDD(&dcA.super, n);
+                        parsec_dtd_insert_task(dtd_tp, gemm_fct,
+                                               (total - m) * (total - m) * (total - m) + 3 * ((2 * total) - m - n - 3) * (m - n) + 6 * (m - k) /*priority*/,
+                                               target_device,
+                                               "Gemm",
+                                               sizeof(int), &transA_g, PARSEC_VALUE,
+                                               sizeof(int), &transB, PARSEC_VALUE,
+                                               sizeof(int), &dcA.super.mb, PARSEC_VALUE,
+                                               sizeof(int), &tempmm, PARSEC_VALUE,
+                                               sizeof(int), &dcA.super.mb, PARSEC_VALUE,
+                                               sizeof(dplasma_complex64_t), &alpha_herk, PARSEC_VALUE,
+                                               PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, m), PARSEC_INPUT | TILE_FULL,
+                                               sizeof(int), &ldak, PARSEC_VALUE,
+                                               PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, k, n), PARSEC_INPUT | TILE_FULL,
+                                               sizeof(int), &ldak, PARSEC_VALUE,
+                                               sizeof(dplasma_complex64_t), &beta, PARSEC_VALUE,
+                                               PASSED_BY_REF, PARSEC_DTD_TILE_OF(A, m, n), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
+                                               sizeof(int), &ldan, PARSEC_VALUE,
+                                               PARSEC_DTD_ARG_END);
+                    }
+                    parsec_dtd_data_flush(dtd_tp, PARSEC_DTD_TILE_OF(A, k, m));
+                }
             }
         }
-    } else {
-        side = dplasmaLeft;
-        transA_p = dplasmaConjTrans;
-        diag = dplasmaNonUnit;
-        alpha_trsm = 1.0;
-        trans = dplasmaConjTrans;
-        alpha_herk = -1.0;
-        beta = 1.0;
-        transB = dplasmaNoTrans;
-        transA_g = dplasmaConjTrans;
 
-        total = dcA.super.nt;
+        parsec_dtd_data_flush_all(dtd_tp, (parsec_data_collection_t *)&dcA);
 
-        for( k = 0; k < total; k++ ) {
-            tempkm = k == dcA.super.nt-1 ? dcA.super.n-k*dcA.super.nb : dcA.super.nb;
-            ldak = BLKLDD(&dcA.super, k);
-            parsec_dtd_insert_task( dtd_tp, parsec_core_potrf,
-                        (total - k) * (total-k) * (total - k)/*priority*/, PARSEC_DEV_CPU, "Potrf",
-                               sizeof(int),      &uplo,              PARSEC_VALUE,
-                               sizeof(int),      &tempkm,            PARSEC_VALUE,
-                               PASSED_BY_REF,    PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                               sizeof(int),      &ldak,              PARSEC_VALUE,
-                               sizeof(int *),    &info,              PARSEC_SCRATCH,
-                               PARSEC_DTD_ARG_END );
+        /* finishing all the tasks inserted, but not finishing the handle */
+        parsec_dtd_taskpool_wait(dtd_tp);
 
-            for( m = k+1; m < total; m++ ) {
-                tempmm = m == dcA.super.nt-1 ? dcA.super.n-m*dcA.super.nb : dcA.super.nb;
-                parsec_dtd_insert_task( dtd_tp, parsec_core_trsm,
-                             (total - m) * (total-m) * (total - m) + 3 * ((2 * total) - k - m - 1) * (m - k)/*priority*/,
-                             PARSEC_DEV_CPU, "Trsm",
-                                   sizeof(int),      &side,               PARSEC_VALUE,
-                                   sizeof(int),      &uplo,               PARSEC_VALUE,
-                                   sizeof(int),      &transA_p,           PARSEC_VALUE,
-                                   sizeof(int),      &diag,               PARSEC_VALUE,
-                                   sizeof(int),      &dcA.super.nb,    PARSEC_VALUE,
-                                   sizeof(int),      &tempmm,             PARSEC_VALUE,
-                                   sizeof(dplasma_complex64_t),      &alpha_trsm,         PARSEC_VALUE,
-                                   PASSED_BY_REF,    PARSEC_DTD_TILE_OF(A, k, k), PARSEC_INPUT | TILE_FULL,
-                                   sizeof(int),      &ldak,               PARSEC_VALUE,
-                                   PASSED_BY_REF,    PARSEC_DTD_TILE_OF(A, k, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                   sizeof(int),      &ldak,               PARSEC_VALUE,
-                                   PARSEC_DTD_ARG_END );
-            }
-            parsec_dtd_data_flush( dtd_tp, PARSEC_DTD_TILE_OF(A, k, k) );
+        /* Waiting on all handle and turning everything off for this context */
+        parsec_context_wait(parsec);
 
-            for( m = k+1; m < dcA.super.mt; m++ ) {
-                tempmm = m == dcA.super.nt-1 ? dcA.super.n-m*dcA.super.nb : dcA.super.nb;
-                ldam = BLKLDD(&dcA.super, m);
-                parsec_dtd_insert_task( dtd_tp, parsec_core_herk,
-                            (total - m) * (total - m) * (total - m) + 3 * (m - k)/*priority*/,
-                            PARSEC_DEV_CPU, "Herk",
-                                   sizeof(int),       &uplo,               PARSEC_VALUE,
-                                   sizeof(int),       &trans,              PARSEC_VALUE,
-                                   sizeof(int),       &tempmm,             PARSEC_VALUE,
-                                   sizeof(int),       &dcA.super.mb,    PARSEC_VALUE,
-                                   sizeof(dplasma_complex64_t),       &alpha_herk,         PARSEC_VALUE,
-                                   PASSED_BY_REF,     PARSEC_DTD_TILE_OF(A, k, m), PARSEC_INPUT | TILE_FULL,
-                                   sizeof(int),       &ldak,               PARSEC_VALUE,
-                                   sizeof(dplasma_complex64_t),    &beta,                  PARSEC_VALUE,
-                                   PASSED_BY_REF,     PARSEC_DTD_TILE_OF(A, m, m), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                   sizeof(int),       &ldam,               PARSEC_VALUE,
-                                   PARSEC_DTD_ARG_END );
+        /* #### PaRSEC context is done #### */
 
-                for( n = m+1; n < total; n++ ) {
-                   ldan = BLKLDD(&dcA.super, n);
-                   parsec_dtd_insert_task( dtd_tp,  gemm_fct,
-                                      (total - m) * (total - m) * (total - m) + 3 * ((2 * total) - m - n - 3) * (m - n) + 6 * (m - k) /*priority*/,
-#if defined(PARSEC_HAVE_CUDA)
-                                      PARSEC_DEV_CUDA,
-#else
-                                      PARSEC_DEV_CPU,
-#endif  /* defined(PARSEC_HAVE_CUDA) */
-                                      "Gemm",
-                                      sizeof(int),        &transA_g,           PARSEC_VALUE,
-                                      sizeof(int),        &transB,             PARSEC_VALUE,
-                                      sizeof(int),        &dcA.super.mb,    PARSEC_VALUE,
-                                      sizeof(int),        &tempmm,             PARSEC_VALUE,
-                                      sizeof(int),        &dcA.super.mb,    PARSEC_VALUE,
-                                      sizeof(dplasma_complex64_t),        &alpha_herk,         PARSEC_VALUE,
-                                      PASSED_BY_REF,      PARSEC_DTD_TILE_OF(A, k, m), PARSEC_INPUT | TILE_FULL,
-                                      sizeof(int),        &ldak,               PARSEC_VALUE,
-                                      PASSED_BY_REF,      PARSEC_DTD_TILE_OF(A, k, n), PARSEC_INPUT | TILE_FULL,
-                                      sizeof(int),        &ldak,               PARSEC_VALUE,
-                                      sizeof(dplasma_complex64_t),        &beta,               PARSEC_VALUE,
-                                      PASSED_BY_REF,      PARSEC_DTD_TILE_OF(A, m, n), PARSEC_INOUT | TILE_FULL | PARSEC_AFFINITY,
-                                      sizeof(int),        &ldan,               PARSEC_VALUE,
-                                      PARSEC_DTD_ARG_END );
-                }
-                parsec_dtd_data_flush( dtd_tp, PARSEC_DTD_TILE_OF(A, k, m) );
-            }
+        if( t > 0 ) {
+            SYNC_TIME_PRINT(rank, ("\tPxQ= %3d %-3d NB= %4d N= %7d : %14f gflops\n",
+                    P, Q, NB, N,
+                    gflops = (flops / 1e9) / sync_time_elapsed));
+            gflops_avg += gflops / nruns;
         }
     }
-
-    parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcA );
-
-    /* finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
-
-    /* Waiting on all handle and turning everything off for this context */
-    parsec_context_wait( parsec );
-
-    /* #### PaRSEC context is done #### */
-
-    SYNC_TIME_PRINT(rank, ("\tPxQ= %3d %-3d NB= %4d N= %7d : %14f gflops\n",
-                           P, Q, NB, N,
-                           gflops=(flops/1e9)/sync_time_elapsed));
+    PASTE_CODE_PERF_LOOP_DONE();
 
     /* Cleaning up the parsec handle */
-    parsec_taskpool_free( dtd_tp );
+    parsec_taskpool_free(dtd_tp);
 
     if( 0 == rank && info != 0 ) {
         printf("-- Factorization is suspicious (info = %d) ! \n", info);
@@ -483,55 +497,59 @@ int main(int argc, char **argv)
     if( !info && check ) {
         /* Check the factorization */
         PASTE_CODE_ALLOCATE_MATRIX(dcA0, check,
-            parsec_matrix_sym_block_cyclic, (&dcA0, PARSEC_MATRIX_COMPLEX_DOUBLE,
-                                       rank, MB, NB, LDA, N, 0, 0,
-                                       N, N, P, nodes/P, uplo));
-        dplasma_zplghe( parsec, (double)(N), uplo,
-                        (parsec_tiled_matrix_t *)&dcA0, random_seed);
+                                   parsec_matrix_sym_block_cyclic, (&dcA0, PARSEC_MATRIX_COMPLEX_DOUBLE,
+                rank, MB, NB, LDA, N, 0, 0,
+                N, N, P, nodes / P, uplo));
+        dplasma_zplghe(parsec, (double)(N), uplo,
+                       (parsec_tiled_matrix_t *)&dcA0, random_seed);
 
-        ret |= check_zpotrf( parsec, (rank == 0) ? loud : 0, uplo,
-                             (parsec_tiled_matrix_t *)&dcA,
-                             (parsec_tiled_matrix_t *)&dcA0);
+        ret |= check_zpotrf(parsec, (rank == 0) ? loud : 0, uplo,
+                            (parsec_tiled_matrix_t *)&dcA,
+                            (parsec_tiled_matrix_t *)&dcA0);
 
         /* Check the solution */
         PASTE_CODE_ALLOCATE_MATRIX(dcB, check,
-            parsec_matrix_block_cyclic, (&dcB, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
-                                   rank, MB, NB, LDB, NRHS, 0, 0,
-                                   N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, random_seed+1);
+                                   parsec_matrix_block_cyclic, (&dcB, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
+                rank, MB, NB, LDB, NRHS, 0, 0,
+                N, NRHS, P, nodes / P, KP, KQ, IP, JQ));
+        dplasma_zplrnt(parsec, 0, (parsec_tiled_matrix_t *)&dcB, random_seed + 1);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcX, check,
-            parsec_matrix_block_cyclic, (&dcX, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
-                                   rank, MB, NB, LDB, NRHS, 0, 0,
-                                   N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
-        dplasma_zlacpy( parsec, dplasmaUpperLower,
-                        (parsec_tiled_matrix_t *)&dcB, (parsec_tiled_matrix_t *)&dcX );
+                                   parsec_matrix_block_cyclic, (&dcX, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
+                rank, MB, NB, LDB, NRHS, 0, 0,
+                N, NRHS, P, nodes / P, KP, KQ, IP, JQ));
+        dplasma_zlacpy(parsec, dplasmaUpperLower,
+                       (parsec_tiled_matrix_t *)&dcB, (parsec_tiled_matrix_t *)&dcX);
 
         dplasma_zpotrs(parsec, uplo,
                        (parsec_tiled_matrix_t *)&dcA,
-                       (parsec_tiled_matrix_t *)&dcX );
+                       (parsec_tiled_matrix_t *)&dcX);
 
-        ret |= check_zaxmb( parsec, (rank == 0) ? loud : 0, uplo,
-                            (parsec_tiled_matrix_t *)&dcA0,
-                            (parsec_tiled_matrix_t *)&dcB,
-                            (parsec_tiled_matrix_t *)&dcX);
+        ret |= check_zaxmb(parsec, (rank == 0) ? loud : 0, uplo,
+                           (parsec_tiled_matrix_t *)&dcA0,
+                           (parsec_tiled_matrix_t *)&dcB,
+                           (parsec_tiled_matrix_t *)&dcX);
 
         /* Cleanup */
-        parsec_data_free(dcA0.mat); dcA0.mat = NULL;
-        parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA0 );
-        parsec_data_free(dcB.mat); dcB.mat = NULL;
-        parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcB );
-        parsec_data_free(dcX.mat); dcX.mat = NULL;
-        parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcX );
+        parsec_data_free(dcA0.mat);
+        dcA0.mat = NULL;
+        parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcA0);
+        parsec_data_free(dcB.mat);
+        dcB.mat = NULL;
+        parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcB);
+        parsec_data_free(dcX.mat);
+        dcX.mat = NULL;
+        parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcX);
     }
 
     /* Cleaning data arrays we allocated for communication */
-    dplasma_matrix_del2arena( tile_full );
+    dplasma_matrix_del2arena(tile_full);
     parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
-    parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
+    parsec_dtd_data_collection_fini((parsec_data_collection_t *)&dcA);
 
-    parsec_data_free(dcA.mat); dcA.mat = NULL;
-    parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);
+    parsec_data_free(dcA.mat);
+    dcA.mat = NULL;
+    parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcA);
 
     cleanup_parsec(parsec, iparam);
     return ret;

--- a/tests/testing_zsyr2k.c
+++ b/tests/testing_zsyr2k.c
@@ -71,24 +71,27 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
-        dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
+            dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        /* Create PaRSEC */
-        PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyr2k,
-                                  (uplo, trans,
-                                   alpha, (parsec_tiled_matrix_t *)&dcA,
-                                          (parsec_tiled_matrix_t *)&dcB,
-                                   beta,  (parsec_tiled_matrix_t *)&dcC));
+            /* Create PaRSEC */
+            PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyr2k,
+                                      (uplo, trans,
+                                              alpha, (parsec_tiled_matrix_t *)&dcA,
+                                              (parsec_tiled_matrix_t *)&dcB,
+                                              beta,  (parsec_tiled_matrix_t *)&dcC));
 
-        /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zsyr2k);
+            /* lets rock! */
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyr2k, t);
 
-        dplasma_zsyr2k_Destruct( PARSEC_zsyr2k );
+            dplasma_zsyr2k_Destruct( PARSEC_zsyr2k );
+        }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);

--- a/tests/testing_zsyrk.c
+++ b/tests/testing_zsyrk.c
@@ -58,22 +58,25 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
-        dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
+            dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        /* Create PaRSEC */
-        PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyrk,
-                                  (uplo, trans,
-                                   alpha, (parsec_tiled_matrix_t *)&dcA,
-                                   beta,  (parsec_tiled_matrix_t *)&dcC));
+            /* Create PaRSEC */
+            PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyrk,
+                                      (uplo, trans,
+                                              alpha, (parsec_tiled_matrix_t *)&dcA,
+                                              beta,  (parsec_tiled_matrix_t *)&dcC));
 
-        /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zsyrk);
+            /* lets rock! */
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyrk, t);
 
-        dplasma_zsyrk_Destruct( PARSEC_zsyrk );
+            dplasma_zsyrk_Destruct( PARSEC_zsyrk );
+        }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);

--- a/tests/testing_ztrmm.c
+++ b/tests/testing_ztrmm.c
@@ -68,24 +68,24 @@ int main(int argc, char ** argv)
             dcA = parsec_tiled_matrix_submatrix( (parsec_tiled_matrix_t *)&dcA0, 0, 0, N, N );
         }
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplghe( parsec, 0., uplo, dcA, Aseed);
-        dplasma_zplrnt( parsec, 0,        (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplghe( parsec, 0., uplo, dcA, Aseed);
+            dplasma_zplrnt( parsec, 0,        (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        int t;
-        for(t = 0; t < nruns; t++) {
             parsec_devices_release_memory();
             /* Create PaRSEC */
             PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, ztrmm,
-                                      (side, uplo, trans, diag,
-                                       1.0, dcA,
-                                       (parsec_tiled_matrix_t *)&dcC),
-                                      dplasma_ztrmm_Destruct( PARSEC_ztrmm ));
+                                                        (side, uplo, trans, diag,
+                                                                1.0, dcA,
+                                                                (parsec_tiled_matrix_t *)&dcC),
+                                                                dplasma_ztrmm_Destruct( PARSEC_ztrmm ), t);
 
             parsec_devices_reset_load(parsec);
         }
+        PASTE_CODE_PERF_LOOP_DONE();
         free(dcA);
     }
     else


### PR DESCRIPTION
PR based on https://bitbucket.org/icldistcomp/dplasma/pull-requests/88

For all DPLASMA testing drivers that support timing, add support for the --nruns option (defaults to 3 timed run per execution) with warmup loop iteration.

-x forces --nruns to be 0, meaning only the warmup run (without timing information displayed) is executed to prepare the matrices to check.

Each dpalsma tester does nruns+1 iterations of the main operation (sometimes hard to define for operations that involve multiple DAGs, in this case, each is done nruns+1 times), and only the last nruns timing are displayed, to remove artefacts like the cost of initializing the mathematical library.

This patch also introduces some fixes in a few benchmarks (zheev, the CUDA-enabled DTD that did not manage the case where CUDA is compiled-in but there is no CUDA device available, and a few other issues).
