### PR TITLE
[BBT#89] Dplasma warming run

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(DplasmaCompilerFlags)
 if(NOT TARGET dplasma_tests_common)
   add_library(dplasma_tests_common OBJECT common.c)
+  set_target_properties(dplasma_tests_common PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
   target_include_directories(dplasma_tests_common
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/RulesTestings.cmake
+++ b/tests/RulesTestings.cmake
@@ -30,6 +30,7 @@ function(testings_addexec OUTPUTLIST PRECISIONS)
                             PRIVATE dplasma_tests_common
                             PUBLIC dplasma
                             $<$<BOOL:${MPI_C_FOUND}>:MPI::MPI_C>)
+      set_target_properties(${exec} PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
     endif(NOT TARGET ${exec})
 
     if( CMAKE_Fortran_COMPILER_WORKS )

--- a/tests/common.c
+++ b/tests/common.c
@@ -779,12 +779,6 @@ void dplasma_warmup(parsec_context_t *parsec)
     float beta  = -0.42;
     parsec_matrix_type_t mtype = PARSEC_MATRIX_FLOAT;
 #define DPLASMA_KERNEL  dplasma_sgemm
-#define INIT_MATRIX     dplasma_splrnt
-#elif defined(DPLASMA_CGEMM_NN)
-    dplasma_complex32_t alpha =  0.51 + I * 0.32;
-    dplasma_complex32_t beta  = -0.42 + I * 0.21;
-    parsec_matrix_type_t mtype = PARSEC_MATRIX_COMPLEX_FLOAT;
-#define DPLASMA_KERNEL  dplasma_cgemm
 #define INIT_MATRIX     dplasma_cplrnt
 #elif defined(DPLASMA_ZGEMM_NN)
     dplasma_complex64_t alpha =  0.51 + I * 0.32;
@@ -797,11 +791,7 @@ void dplasma_warmup(parsec_context_t *parsec)
 #endif
 
 #if defined(DPLASMA_KERNEL)
-    int M, N, K;
     int MB;
-    int LDA, LDB, LDC;
-    int P, Q;
-
     int rank = 0;
     int nodes = 1;
 #if defined(PARSEC_HAVE_MPI)

--- a/tests/common.c
+++ b/tests/common.c
@@ -273,7 +273,7 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
     /* Default seed */
     iparam[IPARAM_RANDOM_SEED] = 3872;
     iparam[IPARAM_MATRIX_INIT] = dplasmaMatrixRandom;
-    iparam[IPARAM_NRUNS] = 1;
+    iparam[IPARAM_NRUNS] = 3;
 
     do {
 #if defined(PARSEC_HAVE_GETOPT_LONG)
@@ -443,14 +443,18 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
     if(0 == iparam[IPARAM_N] && optind < argc) {
         iparam[IPARAM_N] = atoi(argv[optind++]);
     }
+
+    /* If we ask for check (-x), then we do '0' run, i.e. only the 'warmup'
+     * run, which is sometimes used to initialize the data and do the initial
+     * computation */
+    if(iparam[IPARAM_CHECK]) {
+        iparam[IPARAM_NRUNS] = 0;
+    }
     (void)rc;
 }
 
 static void parse_arguments(int *iparam) {
     int verbose = iparam[IPARAM_RANK] ? 0 : iparam[IPARAM_VERBOSE];
-
-    /* we want to run at least once, right? */
-    if(iparam[IPARAM_NRUNS] < 1) iparam[IPARAM_NRUNS] = 1;
 
     if(iparam[IPARAM_NGPUS] < 0) iparam[IPARAM_NGPUS] = 0;
     if(iparam[IPARAM_NGPUS] > 0) {

--- a/tests/common.c
+++ b/tests/common.c
@@ -757,3 +757,122 @@ void cleanup_parsec(parsec_context_t* parsec, int *iparam)
     (void)iparam;
 }
 
+void dplasma_warmup(parsec_context_t *parsec)
+{
+    int Aseed = 3872;
+    int Bseed = 4674;
+    int Cseed = 2873;
+    int tA = dplasmaNoTrans;
+    int tB = dplasmaNoTrans;
+
+    // DPLASMA might have been compiled with only one precision, or any subset of the 4 possible
+    // precisions. The following logic tries to find /a/ kernel we can use. We check in the
+    // arbitrary order d, s, c, z, but really we just want any of them.
+#if defined(DPLASMA_DGEMM_NN)
+    double alpha =  0.51;
+    double beta  = -0.42;
+    parsec_matrix_type_t mtype = PARSEC_MATRIX_DOUBLE;
+#define KERNEL_NEW      dplasma_dgemm_New
+#define KERNEL_DESTRUCT dplasma_dgemm_Destruct
+#define INIT_MATRIX     dplasma_dplrnt
+#elif defined(DPLASMA_SGEMM_NN)
+    float alpha =  0.51;
+    float beta  = -0.42;
+    parsec_matrix_type_t mtype = PARSEC_MATRIX_FLOAT;
+#define KERNEL_NEW      dplasma_sgemm_New
+#define KERNEL_DESTRUCT dplasma_sgemm_Destruct
+#define INIT_MATRIX     dplasma_splrnt
+#elif defined(DPLASMA_CGEMM_NN)
+    dplasma_complex32_t alpha =  0.51 + I * 0.32;
+    dplasma_complex32_t beta  = -0.42 + I * 0.21;
+    parsec_matrix_type_t mtype = PARSEC_MATRIX_COMPLEX_FLOAT;
+#define KERNEL_NEW      dplasma_cgemm_New
+#define KERNEL_DESTRUCT dplasma_cgemm_Destruct
+#define INIT_MATRIX     dplasma_cplrnt
+#elif defined(DPLASMA_ZGEMM_NN)
+    dplasma_complex64_t alpha =  0.51 + I * 0.32;
+    dplasma_complex64_t beta  = -0.42 + I * 0.21;
+    parsec_matrix_type_t mtype = PARSEC_MATRIX_COMPLEX_DOUBLE;
+#define KERNEL_NEW      dplasma_zgemm_New
+#define KERNEL_DESTRUCT dplasma_zgemm_Destruct
+#define INIT_MATRIX     dplasma_zplrnt
+#else
+#warning "DPLASMA is configured without any of the sdcz precisions... Warmup will be no-op"
+#endif
+
+#if defined(KERNEL_NEW)
+    int M, N, K;
+    int MB;
+    int LDA, LDB, LDC;
+    int P, Q;
+
+    int rank = parsec->my_rank;
+    int nodes = parsec->nb_nodes;
+
+    int gpus = 0;
+
+#if defined(DPLASMA_HAVE_CUDA)
+    int devid;
+    for(devid = 0; devid < (int)parsec_nb_devices; devid++) {
+        parsec_device_module_t *device = parsec_mca_device_get(devid);
+        if( PARSEC_DEV_CUDA == device->type ) {
+            gpus++;
+        }
+    }
+#endif
+
+    if(0 == gpus) {
+        MB = 512;
+        N = nodes * parsec->virtual_processes[0]->nb_cores * 3 * MB;
+        P = nodes;
+        Q = 1;
+    } else {
+        MB = 64;
+        N = nodes * gpus * 3 * MB;
+        P = nodes;
+        Q = 1;
+    }
+    M = MB;
+    K = MB;
+
+    LDA = MB;
+    LDB = MB;
+    LDC = MB;
+
+    PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
+        parsec_matrix_block_cyclic, (&dcC, mtype, PARSEC_MATRIX_TILE,
+                               rank, MB, MB, LDC, N, 0, 0,
+                               M, N, nodes, P, Q, 1, 0, 0));
+
+    /* initializing matrix structure */
+    PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
+        parsec_matrix_block_cyclic, (&dcA, mtype, PARSEC_MATRIX_TILE,
+                                rank, MB, MB, LDA, K, 0, 0,
+                                M, K, nodes, P, Q, 1, 0, 0));
+    PASTE_CODE_ALLOCATE_MATRIX(dcB, 1,
+        parsec_matrix_block_cyclic, (&dcB, mtype, PARSEC_MATRIX_TILE,
+                                rank, MB, MB, LDB, N, 0, 0,
+                                K, N, nodes, P, Q, 1, 0, 0));
+
+    /* matrix generation */
+    INIT_MATRIX( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
+    INIT_MATRIX( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
+    INIT_MATRIX( parsec, 0, (parsec_tiled_matrix_t *)&dcC, Cseed);
+
+    parsec_devices_release_memory();
+    parsec_taskpool_t* PARSEC_gemm = KERNEL_NEW (tA, tB, alpha, (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcB, beta, (parsec_tiled_matrix_t *)&dcC); 
+    PARSEC_CHECK_ERROR(parsec_context_add_taskpool(parsec, PARSEC_gemm), "parsec_context_add_taskpool"); 
+    PARSEC_CHECK_ERROR(parsec_context_start(parsec), "parsec_context_start"); 
+    PARSEC_CHECK_ERROR(parsec_context_wait(parsec), "parsec_context_wait"); 
+    KERNEL_DESTRUCT ( PARSEC_gemm );
+    parsec_devices_reset_load(parsec);
+
+    parsec_data_free(dcA.mat);
+    parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);
+    parsec_data_free(dcB.mat);
+    parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcB);
+    parsec_data_free(dcC.mat);
+    parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcC);
+
+#endif
+}

--- a/tests/common.c
+++ b/tests/common.c
@@ -764,6 +764,7 @@ void dplasma_warmup(parsec_context_t *parsec)
     int Cseed = 2873;
     int tA = dplasmaNoTrans;
     int tB = dplasmaNoTrans;
+    int M, N, K, P, Q, LDA, LDB, LDC;
 
     // DPLASMA might have been compiled with only one precision, or any subset of the 4 possible
     // precisions. The following logic tries to find /a/ kernel we can use. We check in the

--- a/tests/common.h
+++ b/tests/common.h
@@ -133,15 +133,18 @@ void iparam_default_ibnbmb(int* iparam, int ib, int nb, int mb);
 
 /* Define a double type which not pass through the precision generation process */
 typedef double DagDouble_t;
-#define PASTE_CODE_FLOPS( FORMULA, PARAMS ) \
-  double gflops = -1.0, flops = FORMULA PARAMS;
+#define PASTE_CODE_FLOPS( FORMULA, PARAMS )                             \
+  double gflops = -1.0, flops = FORMULA PARAMS;                         \
+  double gflops_avg = 0.0;
 
 #if defined(PRECISION_z) || defined(PRECISION_c)
-#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS) \
-  double gflops = -1.0, flops = (2. * FADD PARAMS + 6. * FMUL PARAMS);
+#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS)                        \
+  double gflops = -1.0, flops = (2. * FADD PARAMS + 6. * FMUL PARAMS);  \
+  double gflops_avg = 0.0;
 #else
-#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS) \
-  double gflops = -1.0, flops = (FADD PARAMS + FMUL PARAMS);
+#define PASTE_CODE_FLOPS_COUNT(FADD,FMUL,PARAMS)                        \
+  double gflops = -1.0, flops = (FADD PARAMS + FMUL PARAMS);            \
+  double gflops_avg = 0.0;
 #endif
 
 /*******************************
@@ -230,26 +233,20 @@ static inline int min(int a, int b) { return a < b ? a : b; }
     PROFILING_SAVE_iINFO("PARAM_BUT_LEVEL", iparam[IPARAM_BUT_LEVEL]);  \
     PROFILING_SAVE_iINFO("PARAM_SCHEDULER", iparam[IPARAM_SCHEDULER]);  
 
-#define PASTE_CODE_PROGRESS_KERNEL(PARSEC, KERNEL)                      \
+#define PASTE_CODE_PROGRESS_KERNEL(PARSEC, KERNEL, ITERATION)           \
     SYNC_TIME_START();                                                  \
     PARSEC_CHECK_ERROR(parsec_context_start(PARSEC), "parsec_context_start"); \
     TIME_START();                                                       \
     PARSEC_CHECK_ERROR(parsec_context_wait(PARSEC), "parsec_context_wait"); \
-    SYNC_TIME_PRINT(rank, (#KERNEL "\tPxQxg= %3d %-3d %d NB= %4d N= %7d : %14f gflops\n", \
-                           P, Q, gpus, NB, N,                           \
-                           gflops=(flops/1e9)/sync_time_elapsed));      \
-    PASTE_PROF_INFO;                                                    \
-    if(loud >= 5 && rank == 0) {                                        \
-        printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n" \
-               "                 encoding=\"none\" compression=\"none\">\n" \
-               "%g\n"                                                   \
-               "</DartMeasurement>\n",                                  \
-               gflops);                                                 \
-    }                                                                   \
-    (void)gflops;
+    if( (ITERATION) > 0) {                                              \
+        SYNC_TIME_PRINT(rank, (#KERNEL "\tPxQxg= %3d %-3d %d NB= %4d N= %7d : %14f gflops\n", \
+                        P, Q, gpus, NB, N,                              \
+                        gflops=(flops/1e9)/sync_time_elapsed));         \
+        gflops_avg += gflops/nruns;                                     \
+    }
 
 
-#define PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(PARSEC, KERNEL, PARAMS, DESTRUCT)\
+#define PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(PARSEC, KERNEL, PARAMS, DESTRUCT, ITERATION)\
     SYNC_TIME_START();                                                  \
     parsec_taskpool_t* PARSEC_##KERNEL = dplasma_##KERNEL##_New PARAMS; \
     PARSEC_CHECK_ERROR(parsec_context_add_taskpool(PARSEC, PARSEC_##KERNEL), "parsec_context_add_taskpool");\
@@ -265,7 +262,7 @@ static inline int min(int a, int b) { return a < b ? a : b; }
     DESTRUCT;                                                           \
     SYNC_TIME_STOP();                                                   \
     double stime_C = sync_time_elapsed;                                 \
-    if(rank==0){                                                        \
+    if(rank==0 && (ITERATION) > 0) {                                    \
         printf("[****] TIME(s) %12.5f : " #KERNEL "\tPxQxg= %3d %-3d %d NB= %4d N= %7d : %14f gflops"\
                   " - ENQ&PROG&DEST %12.5f : %14f gflops"               \
                   " - ENQ %12.5f - DEST %12.5f\n",                      \
@@ -274,15 +271,19 @@ static inline int min(int a, int b) { return a < b ? a : b; }
                           (stime_A+stime_B+stime_C),                    \
                           (flops/1e9)/(stime_A+stime_B+stime_C),        \
                           stime_A,stime_C);                             \
+        gflops_avg += gflops/nruns;                                     \
     }                                                                   \
+    (void)gflops;
+
+#define PASTE_CODE_PERF_LOOP_DONE()  do {                               \
     PASTE_PROF_INFO;                                                    \
-    if(loud >= 5 && rank == 0) {                                        \
+    if(loud >= 5 && rank == 0 && nruns>0) {                             \
         printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n" \
                "                 encoding=\"none\" compression=\"none\">\n" \
                "%g\n"                                                   \
                "</DartMeasurement>\n",                                  \
-               gflops);                                                 \
+               gflops_avg);                                             \
     }                                                                   \
-    (void)gflops;
+} while(0)
 
 #endif /* _TESTSCOMMON_H */

--- a/tests/testing_zgelqf.c
+++ b/tests/testing_zgelqf.c
@@ -37,6 +37,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGELQF, ((DagDouble_t)M, (DagDouble_t)N));
 
@@ -52,7 +55,7 @@ int main(int argc, char ** argv)
                                MT*IB, N, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns+1; t++) {
+    for(t = 0; t < nruns; t++) {
         /* matrix (re)generation */
         if(loud > 3) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -70,7 +73,7 @@ int main(int argc, char ** argv)
         parsec_context_add_taskpool(parsec, PARSEC_zgelqf);
         if( loud > 2 && t > 0) SYNC_TIME_PRINT(rank, ( "zgelqf\tDAG created\n"));
 
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgelqf, t);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgelqf);
         dplasma_zgelqf_Destruct( PARSEC_zgelqf );
 
         parsec_taskpool_sync_ids(); /* recursive DAGs are not synchronous on ids */

--- a/tests/testing_zgelqf.c
+++ b/tests/testing_zgelqf.c
@@ -52,7 +52,7 @@ int main(int argc, char ** argv)
                                MT*IB, N, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 3) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -61,32 +61,23 @@ int main(int argc, char ** argv)
 
         parsec_devices_release_memory();
 
-        if(iparam[IPARAM_HNB] != iparam[IPARAM_NB])
-        {
-            SYNC_TIME_START();
-            parsec_taskpool_t* PARSEC_zgelqf = dplasma_zgelqf_New( (parsec_tiled_matrix_t*)&dcA,
-                                                                   (parsec_tiled_matrix_t*)&dcT );
-            /* Set the recursive size */
-            //TODO: import recursive from QRF
-            //dplasma_zgelqf_setrecursive( PARSEC_zgelqf, iparam[IPARAM_HNB] );
-            parsec_context_add_taskpool(parsec, PARSEC_zgelqf);
-            if( loud > 2 ) SYNC_TIME_PRINT(rank, ( "zgelqf\tDAG created\n"));
+        SYNC_TIME_START();
+        parsec_taskpool_t* PARSEC_zgelqf = dplasma_zgelqf_New( (parsec_tiled_matrix_t*)&dcA,
+                                                               (parsec_tiled_matrix_t*)&dcT );
 
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zgelqf);
-            dplasma_zgelqf_Destruct( PARSEC_zgelqf );
+        /* TODO: Set the recursive size if iparam[IPARAM_HNB] != iparam[IPARAM_NB]) */
+        //dplasma_zgelqf_setrecursive( PARSEC_zgelqf, iparam[IPARAM_HNB] );
+        parsec_context_add_taskpool(parsec, PARSEC_zgelqf);
+        if( loud > 2 && t > 0) SYNC_TIME_PRINT(rank, ( "zgelqf\tDAG created\n"));
 
-            parsec_taskpool_sync_ids(); /* recursive DAGs are not synchronous on ids */
-        }
-        else
-        {
-            PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgelqf,
-                                      ((parsec_tiled_matrix_t*)&dcA,
-                                      (parsec_tiled_matrix_t*)&dcT),
-                                      dplasma_zgelqf_Destruct( PARSEC_zgelqf ));
-        }
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgelqf, t);
+        dplasma_zgelqf_Destruct( PARSEC_zgelqf );
+
+        parsec_taskpool_sync_ids(); /* recursive DAGs are not synchronous on ids */
+
         parsec_devices_reset_load(parsec);
-
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
 #if defined(PARSEC_SIM)
     {

--- a/tests/testing_zgelqf_hqr.c
+++ b/tests/testing_zgelqf_hqr.c
@@ -81,59 +81,59 @@ int main(int argc, char ** argv)
                                rank, MB, NB, LDB, NRHS, 0, 0,
                                N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
 
-    /* matrix generation */
-    if(loud > 3) printf("+++ Generate matrices ... ");
-    dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
-    if( check )
-        dplasma_zlacpy( parsec, dplasmaUpperLower,
-                        (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
-    if(loud > 3) printf("Done\n");
+    for(int t = 0; t < nruns+1; t++) {
+        if(loud > 3) printf("+++ Generate matrices ... ");
+        dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
+        if(t == 0 && check)
+            dplasma_zlacpy( parsec, dplasmaUpperLower,
+                            (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
+        if(loud > 3) printf("Done\n");
 
-    dplasma_hqr_init( &qrtree,
-                      dplasmaConjTrans, (parsec_tiled_matrix_t *)&dcA,
-                      iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
-                      iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
-                      iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
+        dplasma_hqr_init( &qrtree,
+                          dplasmaConjTrans, (parsec_tiled_matrix_t *)&dcA,
+                          iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
+                          iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
+                          iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
 
-    /* Create PaRSEC */
-    PASTE_CODE_ENQUEUE_KERNEL(parsec, zgelqf_param,
-                              (&qrtree,
-                               (parsec_tiled_matrix_t*)&dcA,
-                               (parsec_tiled_matrix_t*)&dcTS,
-                               (parsec_tiled_matrix_t*)&dcTT));
+        /* Create PaRSEC */
+        PASTE_CODE_ENQUEUE_KERNEL(parsec, zgelqf_param,
+                                  (&qrtree,
+                                          (parsec_tiled_matrix_t*)&dcA,
+                                          (parsec_tiled_matrix_t*)&dcTS,
+                                          (parsec_tiled_matrix_t*)&dcTT));
 
-    /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
-    SYNC_TIME_START();
-    parsec_context_start(parsec);
-    TIME_START();
-    parsec_context_wait(parsec);
+        /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
+        SYNC_TIME_START();
+        parsec_context_start(parsec);
+        TIME_START();
+        parsec_context_wait(parsec);
 
-    SYNC_TIME_PRINT(rank,
-                    ("zgelqf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
-                     iparam[IPARAM_NNODES],
-                     iparam[IPARAM_NCORES],
-                     iparam[IPARAM_P],
-                     iparam[IPARAM_IB],
-                     iparam[IPARAM_MB],
-                     iparam[IPARAM_NB],
-                     iparam[IPARAM_QR_TS_SZE],
-                     iparam[IPARAM_QR_HLVL_SZE],
-                     iparam[IPARAM_LOWLVL_TREE],
-                     iparam[IPARAM_HIGHLVL_TREE],
-                     iparam[IPARAM_QR_DOMINO],
-                     iparam[IPARAM_QR_TSRR],
-                     iparam[IPARAM_M],
-                     iparam[IPARAM_N],
-                     gflops = (flops/1e9)/(sync_time_elapsed)));
-    if(loud >= 5 && rank == 0) {
-        printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n"
-               "                 encoding=\"none\" compression=\"none\">\n"
-               "%g\n"
-               "</DartMeasurement>\n",
-               gflops);
+        if(t > 0) {
+            SYNC_TIME_PRINT(rank,
+                            ("zgelqf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
+                                    iparam[IPARAM_NNODES],
+                                    iparam[IPARAM_NCORES],
+                                    iparam[IPARAM_P],
+                                    iparam[IPARAM_IB],
+                                    iparam[IPARAM_MB],
+                                    iparam[IPARAM_NB],
+                                    iparam[IPARAM_QR_TS_SZE],
+                                    iparam[IPARAM_QR_HLVL_SZE],
+                                    iparam[IPARAM_LOWLVL_TREE],
+                                    iparam[IPARAM_HIGHLVL_TREE],
+                                    iparam[IPARAM_QR_DOMINO],
+                                    iparam[IPARAM_QR_TSRR],
+                                    iparam[IPARAM_M],
+                                    iparam[IPARAM_N],
+                                    gflops = (flops/1e9)/(sync_time_elapsed)));
+            gflops_avg += gflops/nruns;
+        }
+
+        dplasma_zgelqf_param_Destruct( PARSEC_zgelqf_param );
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
 #if defined(PARSEC_SIM)
     if ( rank == 0 ) {
@@ -151,8 +151,6 @@ int main(int argc, char ** argv)
                parsec_getsimulationdate( parsec ));
     }
 #endif
-
-    dplasma_zgelqf_param_Destruct( PARSEC_zgelqf_param );
 
     if( check ) {
         if (N >= M) {

--- a/tests/testing_zgemm.c
+++ b/tests/testing_zgemm.c
@@ -43,6 +43,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     PASTE_CODE_FLOPS(FLOPS_ZGEMM, ((DagDouble_t)M,(DagDouble_t)N,(DagDouble_t)K));
 
     LDA = max(LDA, max(M, K));
@@ -67,7 +69,7 @@ int main(int argc, char ** argv)
                                    K, N, P, nodes/P, KP, KQ, IP, JQ));
 
         int t;
-        for(t = 0; t < nruns+1; t++) {
+        for(t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
@@ -83,8 +85,7 @@ int main(int argc, char ** argv)
                                        (parsec_tiled_matrix_t *)&dcB,
                                        beta,
                                        (parsec_tiled_matrix_t *)&dcC),
-                                      dplasma_zgemm_Destruct( PARSEC_zgemm ),
-                                      t);
+                                      dplasma_zgemm_Destruct( PARSEC_zgemm ));
 
             parsec_devices_reset_load(parsec);
         }
@@ -154,7 +155,7 @@ int main(int argc, char ** argv)
                                (parsec_tiled_matrix_t *)&dcB,
                                (dplasma_complex64_t)beta,
                                (parsec_tiled_matrix_t *)&dcC),
-                               dplasma_zgemm_Destruct( PARSEC_zgemm ), 0);
+                               dplasma_zgemm_Destruct( PARSEC_zgemm ));
 
                 if(loud) printf("Done\n");
 

--- a/tests/testing_zgemm.c
+++ b/tests/testing_zgemm.c
@@ -66,15 +66,15 @@ int main(int argc, char ** argv)
                                    rank, MB, NB, LDB, N, 0, 0,
                                    K, N, P, nodes/P, KP, KQ, IP, JQ));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
-
         int t;
-        for(t = 0; t < nruns; t++) {
+        for(t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
+
             parsec_devices_release_memory();
             /* Create PaRSEC */
             PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgemm,
@@ -83,10 +83,12 @@ int main(int argc, char ** argv)
                                        (parsec_tiled_matrix_t *)&dcB,
                                        beta,
                                        (parsec_tiled_matrix_t *)&dcC),
-                                      dplasma_zgemm_Destruct( PARSEC_zgemm ));
+                                      dplasma_zgemm_Destruct( PARSEC_zgemm ),
+                                      t);
 
             parsec_devices_reset_load(parsec);
         }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);
@@ -152,7 +154,7 @@ int main(int argc, char ** argv)
                                (parsec_tiled_matrix_t *)&dcB,
                                (dplasma_complex64_t)beta,
                                (parsec_tiled_matrix_t *)&dcC),
-                              dplasma_zgemm_Destruct( PARSEC_zgemm ));
+                               dplasma_zgemm_Destruct( PARSEC_zgemm ), 0);
 
                 if(loud) printf("Done\n");
 

--- a/tests/testing_zgeqrf.c
+++ b/tests/testing_zgeqrf.c
@@ -37,6 +37,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGEQRF, ((DagDouble_t)M, (DagDouble_t)N));
 
@@ -55,7 +58,7 @@ int main(int argc, char ** argv)
 
     if(!check) {
         int t;
-        for(t = 0; t < nruns+1; t++) {
+        for(t = 0; t < nruns; t++) {
             /* matrix (re)generation */
             if(loud > 3) printf("+++ Generate matrices ... ");
             dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -74,7 +77,7 @@ int main(int argc, char ** argv)
                 parsec_context_add_taskpool(parsec, PARSEC_zgeqrf);
                 if( loud > 2 ) SYNC_TIME_PRINT(rank, ( "zgeqrf\tDAG created\n"));
 
-                PASTE_CODE_PROGRESS_KERNEL(parsec, zgeqrf, t);
+                PASTE_CODE_PROGRESS_KERNEL(parsec, zgeqrf);
                 dplasma_zgeqrf_Destruct( PARSEC_zgeqrf );
 
                 parsec_taskpool_sync_ids(); /* recursive DAGs are not synchronous on ids */
@@ -84,7 +87,7 @@ int main(int argc, char ** argv)
                 PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgeqrf,
                                                             ((parsec_tiled_matrix_t*)&dcA,
                                                                     (parsec_tiled_matrix_t*)&dcT),
-                                                                    dplasma_zgeqrf_Destruct( PARSEC_zgeqrf ), t);
+                                                                    dplasma_zgeqrf_Destruct( PARSEC_zgeqrf ));
             }
             parsec_devices_reset_load(parsec);
 

--- a/tests/testing_zgeqrf_hqr.c
+++ b/tests/testing_zgeqrf_hqr.c
@@ -81,59 +81,61 @@ int main(int argc, char ** argv)
                                rank, MB, NB, LDB, NRHS, 0, 0,
                                M, NRHS, P, nodes/P, KP, KQ, IP, JQ));
 
-    /* matrix generation */
-    if(loud > 3) printf("+++ Generate matrices ... ");
-    dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
-    if( check )
-        dplasma_zlacpy( parsec, dplasmaUpperLower,
-                        (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
-    dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
-    if(loud > 3) printf("Done\n");
+    for(int t = 0; t < nruns+1; t++) {
+        /* matrix generation */
+        if(loud > 3) printf("+++ Generate matrices ... ");
+        dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
+        if(0 == t && check) {
+            dplasma_zlacpy( parsec, dplasmaUpperLower,
+                            (parsec_tiled_matrix_t *)&dcA, (parsec_tiled_matrix_t *)&dcA0 );
+        }
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTS);
+        dplasma_zlaset( parsec, dplasmaUpperLower, 0., 0., (parsec_tiled_matrix_t *)&dcTT);
+        if(loud > 3) printf("Done\n");
 
-    dplasma_hqr_init( &qrtree,
-                      dplasmaNoTrans, (parsec_tiled_matrix_t *)&dcA,
-                      iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
-                      iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
-                      iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
+        dplasma_hqr_init( &qrtree,
+                          dplasmaNoTrans, (parsec_tiled_matrix_t *)&dcA,
+                          iparam[IPARAM_LOWLVL_TREE], iparam[IPARAM_HIGHLVL_TREE],
+                          iparam[IPARAM_QR_TS_SZE],   iparam[IPARAM_QR_HLVL_SZE],
+                          iparam[IPARAM_QR_DOMINO],   iparam[IPARAM_QR_TSRR] );
 
-    /* Create PaRSEC */
-    PASTE_CODE_ENQUEUE_KERNEL(parsec, zgeqrf_param,
-                              (&qrtree,
-                               (parsec_tiled_matrix_t*)&dcA,
-                               (parsec_tiled_matrix_t*)&dcTS,
-                               (parsec_tiled_matrix_t*)&dcTT));
+        /* Create PaRSEC */
+        PASTE_CODE_ENQUEUE_KERNEL(parsec, zgeqrf_param,
+                                  (&qrtree,
+                                          (parsec_tiled_matrix_t*)&dcA,
+                                          (parsec_tiled_matrix_t*)&dcTS,
+                                          (parsec_tiled_matrix_t*)&dcTT));
 
-    /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
-    SYNC_TIME_START();
-    parsec_context_start(parsec);
-    TIME_START();
-    parsec_context_wait(parsec);
+        /* lets rock! This code should be copy the PASTE_CODE_PROGRESS_KERNEL macro */
+        SYNC_TIME_START();
+        parsec_context_start(parsec);
+        TIME_START();
+        parsec_context_wait(parsec);
 
-    SYNC_TIME_PRINT(rank,
-                    ("zgeqrf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
-                     iparam[IPARAM_NNODES],
-                     iparam[IPARAM_NCORES],
-                     iparam[IPARAM_P],
-                     iparam[IPARAM_IB],
-                     iparam[IPARAM_MB],
-                     iparam[IPARAM_NB],
-                     iparam[IPARAM_QR_TS_SZE],
-                     iparam[IPARAM_QR_HLVL_SZE],
-                     iparam[IPARAM_LOWLVL_TREE],
-                     iparam[IPARAM_HIGHLVL_TREE],
-                     iparam[IPARAM_QR_DOMINO],
-                     iparam[IPARAM_QR_TSRR],
-                     iparam[IPARAM_M],
-                     iparam[IPARAM_N],
-                     gflops = (flops/1e9)/(sync_time_elapsed)));
-    if(loud >= 5 && rank == 0) {
-        printf("<DartMeasurement name=\"performance\" type=\"numeric/double\"\n"
-               "                 encoding=\"none\" compression=\"none\">\n"
-               "%g\n"
-               "</DartMeasurement>\n",
-               gflops);
+        if(t > 0) {
+            SYNC_TIME_PRINT(rank,
+                            ("zgeqrf HQR computation NP= %d NC= %d P= %d IB= %d MB= %d NB= %d qr_a= %d qr_p = %d treel= %d treeh= %d domino= %d RR= %d M= %d N= %d : %f gflops\n",
+                                    iparam[IPARAM_NNODES],
+                                    iparam[IPARAM_NCORES],
+                                    iparam[IPARAM_P],
+                                    iparam[IPARAM_IB],
+                                    iparam[IPARAM_MB],
+                                    iparam[IPARAM_NB],
+                                    iparam[IPARAM_QR_TS_SZE],
+                                    iparam[IPARAM_QR_HLVL_SZE],
+                                    iparam[IPARAM_LOWLVL_TREE],
+                                    iparam[IPARAM_HIGHLVL_TREE],
+                                    iparam[IPARAM_QR_DOMINO],
+                                    iparam[IPARAM_QR_TSRR],
+                                    iparam[IPARAM_M],
+                                    iparam[IPARAM_N],
+                                    gflops = (flops/1e9)/(sync_time_elapsed)));
+            gflops_avg += gflops/nruns;
+        }
+
+        dplasma_zgeqrf_param_Destruct( PARSEC_zgeqrf_param );
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
 #if defined(PARSEC_SIM)
     if ( rank == 0 ) {
@@ -151,8 +153,6 @@ int main(int argc, char ** argv)
                parsec_getsimulationdate( parsec ));
     }
 #endif
-
-    dplasma_zgeqrf_param_Destruct( PARSEC_zgeqrf_param );
 
     if( check ) {
         if (M >= N) {

--- a/tests/testing_zgeqrf_rd.c
+++ b/tests/testing_zgeqrf_rd.c
@@ -38,6 +38,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGEQRF, ((DagDouble_t)M, (DagDouble_t)N));
 
@@ -83,7 +86,7 @@ int main(int argc, char ** argv)
                                rank, MB, NB, LDB, NRHS, 0, 0,
                                N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
 
-    for(int t = 0; t < nruns+1; t++) {
+    for(int t = 0; t < nruns; t++) {
         /* matrix generation */
         if(loud > 3) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, 3872);
@@ -100,7 +103,7 @@ int main(int argc, char ** argv)
                                           (parsec_tiled_matrix_t*)&dcT));
 
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgeqrf, t);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgeqrf);
         dplasma_zgeqrf_Destruct( PARSEC_zgeqrf );
     }
     PASTE_CODE_PERF_LOOP_DONE();

--- a/tests/testing_zgetrf_1d.c
+++ b/tests/testing_zgetrf_1d.c
@@ -63,7 +63,7 @@ int main(int argc, char ** argv)
                                                       1, dplasma_imin(M, N), P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -77,12 +77,13 @@ int main(int argc, char ** argv)
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_1d,
                           ((parsec_tiled_matrix_t*)&dcA,
                            (parsec_tiled_matrix_t*)&dcIPIV, &info),
-                          dplasma_zgetrf_1d_Destruct( PARSEC_zgetrf_1d ));
+                          dplasma_zgetrf_1d_Destruct( PARSEC_zgetrf_1d ), t);
 
         if(loud > 2) printf("Done.\n");
 
         parsec_devices_reset_load(parsec);
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_1d.c
+++ b/tests/testing_zgetrf_1d.c
@@ -37,6 +37,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGETRF, ((DagDouble_t)M,(DagDouble_t)N));
 
@@ -63,7 +66,7 @@ int main(int argc, char ** argv)
                                                       1, dplasma_imin(M, N), P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns+1; t++) {
+    for(t = 0; t < nruns; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -77,7 +80,7 @@ int main(int argc, char ** argv)
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_1d,
                           ((parsec_tiled_matrix_t*)&dcA,
                            (parsec_tiled_matrix_t*)&dcIPIV, &info),
-                          dplasma_zgetrf_1d_Destruct( PARSEC_zgetrf_1d ), t);
+                          dplasma_zgetrf_1d_Destruct( PARSEC_zgetrf_1d ));
 
         if(loud > 2) printf("Done.\n");
 

--- a/tests/testing_zgetrf_incpiv.c
+++ b/tests/testing_zgetrf_incpiv.c
@@ -36,6 +36,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGETRF, ((DagDouble_t)M,(DagDouble_t)N));
 
@@ -61,7 +64,7 @@ int main(int argc, char ** argv)
                                M, NT, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns+1; t++) {
+    for(t = 0; t < nruns; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -75,7 +78,7 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t*)&dcIPIV,
                             &info));
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_incpiv, t);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_incpiv);
         dplasma_zgetrf_incpiv_Destruct( PARSEC_zgetrf_incpiv );
         if(loud > 2) printf("Done.\n");
     }

--- a/tests/testing_zgetrf_incpiv.c
+++ b/tests/testing_zgetrf_incpiv.c
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
                                M, NT, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -75,10 +75,11 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t*)&dcIPIV,
                             &info));
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_incpiv);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_incpiv, t);
         dplasma_zgetrf_incpiv_Destruct( PARSEC_zgetrf_incpiv );
         if(loud > 2) printf("Done.\n");
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_nopiv.c
+++ b/tests/testing_zgetrf_nopiv.c
@@ -52,7 +52,7 @@ int main(int argc, char ** argv)
                                                       M, N, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -65,13 +65,14 @@ int main(int argc, char ** argv)
 
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_nopiv, 
                           ((parsec_tiled_matrix_t*)&dcA, &info),
-                          dplasma_zgetrf_nopiv_Destruct( PARSEC_zgetrf_nopiv ));
+                          dplasma_zgetrf_nopiv_Destruct( PARSEC_zgetrf_nopiv ), t);
 
         if(loud > 2) printf("Done.\n");
 
         parsec_devices_reset_load(parsec);
 
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_nopiv.c
+++ b/tests/testing_zgetrf_nopiv.c
@@ -35,6 +35,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGETRF, ((DagDouble_t)M,(DagDouble_t)N));
 
@@ -52,7 +55,7 @@ int main(int argc, char ** argv)
                                                       M, N, P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns+1; t++) {
+    for(t = 0; t < nruns; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -65,7 +68,7 @@ int main(int argc, char ** argv)
 
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_nopiv, 
                           ((parsec_tiled_matrix_t*)&dcA, &info),
-                          dplasma_zgetrf_nopiv_Destruct( PARSEC_zgetrf_nopiv ), t);
+                          dplasma_zgetrf_nopiv_Destruct( PARSEC_zgetrf_nopiv ));
 
         if(loud > 2) printf("Done.\n");
 

--- a/tests/testing_zgetrf_ptgpanel.c
+++ b/tests/testing_zgetrf_ptgpanel.c
@@ -36,6 +36,9 @@ int main(int argc, char ** argv)
 
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZGETRF, ((DagDouble_t)M, (DagDouble_t)N));
 
@@ -58,7 +61,7 @@ int main(int argc, char ** argv)
                                P, dplasma_imin(M, N), P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns+1; t++) {
+    for(t = 0; t < nruns; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -72,7 +75,7 @@ int main(int argc, char ** argv)
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_ptgpanel,
                   ((parsec_tiled_matrix_t*)&dcA,
                    (parsec_tiled_matrix_t*)&dcIPIV, &info),
-                  dplasma_zgetrf_ptgpanel_Destruct( PARSEC_zgetrf_ptgpanel ), t);
+                  dplasma_zgetrf_ptgpanel_Destruct( PARSEC_zgetrf_ptgpanel ));
 
         if(loud > 2) printf("Done.\n");
 

--- a/tests/testing_zgetrf_ptgpanel.c
+++ b/tests/testing_zgetrf_ptgpanel.c
@@ -58,7 +58,7 @@ int main(int argc, char ** argv)
                                P, dplasma_imin(M, N), P, nodes/P, KP, KQ, IP, JQ));
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, random_seed);
@@ -72,12 +72,13 @@ int main(int argc, char ** argv)
         PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, zgetrf_ptgpanel,
                   ((parsec_tiled_matrix_t*)&dcA,
                    (parsec_tiled_matrix_t*)&dcIPIV, &info),
-                  dplasma_zgetrf_ptgpanel_Destruct( PARSEC_zgetrf_ptgpanel ));
+                  dplasma_zgetrf_ptgpanel_Destruct( PARSEC_zgetrf_ptgpanel ), t);
 
         if(loud > 2) printf("Done.\n");
 
         parsec_devices_reset_load(parsec);
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_qrf.c
+++ b/tests/testing_zgetrf_qrf.c
@@ -76,7 +76,7 @@ int main(int argc, char ** argv)
     lu_tab = (int *)malloc( dplasma_imin(MT, NT)*sizeof(int) );
 
     int t;
-    for(t = 0; t < nruns; t++) {
+    for(t = 0; t < nruns+1; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -104,7 +104,7 @@ int main(int argc, char ** argv)
                          iparam[IPARAM_QR_HLVL_SZE], alpha, lu_tab,
                          &info));
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_qrf);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_qrf, t);
         dplasma_zgetrf_qrf_Destruct( PARSEC_zgetrf_qrf );
         if(loud > 2) printf("Done.\n");
 
@@ -135,6 +135,7 @@ int main(int argc, char ** argv)
             printf("\n");
         }
     }
+    PASTE_CODE_PERF_LOOP_DONE();
 
     if ( info != 0 ) {
         if( rank == 0 && loud ) printf("-- Factorization is suspicious (info = %d) ! \n", info );

--- a/tests/testing_zgetrf_qrf.c
+++ b/tests/testing_zgetrf_qrf.c
@@ -41,6 +41,8 @@ int main(int argc, char ** argv)
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
 
+    dplasma_warmup(parsec);
+
     /* Make sure KP and KQ are set to 1, since it conflicts with HQR */
     iparam[IPARAM_KP] = 1;
     iparam[IPARAM_KQ] = 1;
@@ -76,7 +78,7 @@ int main(int argc, char ** argv)
     lu_tab = (int *)malloc( dplasma_imin(MT, NT)*sizeof(int) );
 
     int t;
-    for(t = 0; t < nruns+1; t++) {
+    for(t = 0; t < nruns; t++) {
         /* matrix (re)generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zpltmg( parsec, matrix_init, (parsec_tiled_matrix_t *)&dcA, random_seed );
@@ -104,7 +106,7 @@ int main(int argc, char ** argv)
                          iparam[IPARAM_QR_HLVL_SZE], alpha, lu_tab,
                          &info));
         /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_qrf, t);
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zgetrf_qrf);
         dplasma_zgetrf_qrf_Destruct( PARSEC_zgetrf_qrf );
         if(loud > 2) printf("Done.\n");
 

--- a/tests/testing_zhbrdt.c
+++ b/tests/testing_zhbrdt.c
@@ -27,6 +27,9 @@ int main(int argc, char *argv[])
     iparam[IPARAM_NGPUS] = DPLASMA_ERR_NOT_SUPPORTED;
 
     parsec = setup_parsec(argc, argv, iparam);
+
+    dplasma_warmup(parsec);
+
     PASTE_CODE_IPARAM_LOCALS(iparam);
     if(P != 1)
         fprintf(stderr, "!!! This algorithm works on a band 1D matrix. The value of P=%d has been overriden, the actual grid is %dx%d\n", P, 1, nodes);
@@ -47,7 +50,7 @@ int main(int argc, char *argv[])
 
     double time_avg = 0.0;
 
-    for(int t = 0; t < nruns+1; t++) {
+    for(int t = 0; t < nruns; t++) {
         if(loud > 2) printf("+++ Generate matrices ... ");
         dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, 3872);
         if(loud > 2) printf("Done\n");
@@ -55,10 +58,8 @@ int main(int argc, char *argv[])
         PASTE_CODE_ENQUEUE_KERNEL(parsec, zhbrdt,
                                   ((parsec_tiled_matrix_t*)&dcA));
 
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zhbrdt, t);
-        if(t > 0) {
-            time_avg += sync_time_elapsed/nruns;
-        }
+        PASTE_CODE_PROGRESS_KERNEL(parsec, zhbrdt);
+        time_avg += sync_time_elapsed/nruns;
         dplasma_zhbrdt_Destruct( PARSEC_zhbrdt );
     }
     PASTE_PROF_INFO;

--- a/tests/testing_zhemm.c
+++ b/tests/testing_zhemm.c
@@ -37,6 +37,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     LDB = max(LDB, M);
     LDC = max(LDC, M);
 
@@ -69,7 +71,7 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDA, Am, 0, 0,
                                        Am, Am, P, nodes/P, uplo));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplghe( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcA, Aseed);
@@ -85,7 +87,7 @@ int main(int argc, char ** argv)
                                               beta,  (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zhemm, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zhemm);
 
             dplasma_zhemm_Destruct( PARSEC_zhemm );
         }

--- a/tests/testing_zher2k.c
+++ b/tests/testing_zher2k.c
@@ -66,24 +66,27 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
-        dplasma_zplghe( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
+            dplasma_zplghe( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        /* Create PaRSEC */
-        PASTE_CODE_ENQUEUE_KERNEL(parsec, zher2k,
-                                  (uplo, trans,
-                                   alpha, (parsec_tiled_matrix_t *)&dcA,
-                                          (parsec_tiled_matrix_t *)&dcB,
-                                   beta,  (parsec_tiled_matrix_t *)&dcC));
+            /* Create PaRSEC */
+            PASTE_CODE_ENQUEUE_KERNEL(parsec, zher2k,
+                                      (uplo, trans,
+                                              alpha, (parsec_tiled_matrix_t *)&dcA,
+                                              (parsec_tiled_matrix_t *)&dcB,
+                                              beta,  (parsec_tiled_matrix_t *)&dcC));
 
-        /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zher2k);
+            /* lets rock! */
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zher2k, t);
 
-        dplasma_zher2k_Destruct( PARSEC_zher2k );
+            dplasma_zher2k_Destruct( PARSEC_zher2k );
+        }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);

--- a/tests/testing_zher2k.c
+++ b/tests/testing_zher2k.c
@@ -37,6 +37,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     M = N;
     LDC = dplasma_imax(LDC, N);
 
@@ -66,7 +68,7 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
@@ -82,7 +84,7 @@ int main(int argc, char ** argv)
                                               beta,  (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zher2k, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zher2k);
 
             dplasma_zher2k_Destruct( PARSEC_zher2k );
         }

--- a/tests/testing_zherk.c
+++ b/tests/testing_zherk.c
@@ -36,6 +36,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     M = N;
     LDC = max(LDC, N);
 
@@ -59,7 +61,7 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
@@ -73,7 +75,7 @@ int main(int argc, char ** argv)
                                               beta,  (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zherk, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zherk);
 
             dplasma_zherk_Destruct( PARSEC_zherk );
         }

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -43,7 +43,7 @@ parsec_core_trsm(parsec_execution_stream_t *es, parsec_task_t *this_task)
 {
     (void)es;
     int side, uplo, trans, diag;
-    int  m, n, lda, ldc;
+    int m, n, lda, ldc;
     dplasma_complex64_t alpha;
     dplasma_complex64_t *A, *C;
 
@@ -74,7 +74,7 @@ parsec_core_herk(parsec_execution_stream_t *es, parsec_task_t *this_task)
 
     CORE_zherk(uplo, trans, m, n,
                alpha, A, lda,
-               beta,  C, ldc);
+               beta, C, ldc);
 
     return PARSEC_HOOK_RETURN_DONE;
 }
@@ -96,17 +96,17 @@ parsec_core_gemm(parsec_execution_stream_t *es, parsec_task_t *this_task)
     CORE_zgemm(transA, transB,
                m, n, k,
                alpha, A, lda,
-                      B, ldb,
-               beta,  C, ldc);
+               B, ldb,
+               beta, C, ldc);
 
     return PARSEC_HOOK_RETURN_DONE;
 }
 
 #if defined(DPLASMA_HAVE_CUDA)
 static int
-gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
-                                       parsec_gpu_task_t * gpu_task,
-                                       parsec_gpu_exec_stream_t * gpu_stream)
+gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t *gpu_device,
+                                       parsec_gpu_task_t *gpu_task,
+                                       parsec_gpu_exec_stream_t *gpu_stream)
 {
     int transA, transB;
     int m, n, k, lda, ldb, ldc;
@@ -115,14 +115,14 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
     dplasma_complex64_t *B;
     dplasma_complex64_t *C;
     parsec_task_t *this_task = gpu_task->ec;
-    parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t*)gpu_stream;
-    parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t*)gpu_device;
+    parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t *)gpu_stream;
+    parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t *)gpu_device;
 
     parsec_dtd_unpack_args(this_task, &transA, &transB, &m, &n, &k, &alpha,
                            &A, &lda, &B, &ldb, &beta, &C, &ldc);
 
 #if defined(PRECISION_z) || defined(PRECISION_c)
-    cuDoubleComplex zone  = make_cuDoubleComplex( 1., 0.);
+    cuDoubleComplex zone = make_cuDoubleComplex(1., 0.);
     cuDoubleComplex mzone = make_cuDoubleComplex(-1., 0.);
 #else
     double zone  =  1.;
@@ -141,15 +141,15 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
 
     cublasStatus_t status;
 
-    cublasSetKernelStream( cuda_stream->cuda_stream );
-    cublasZgemm( 'N', dplasma_lapack_const(dplasmaConjTrans),
-                 n, n, k,
-                 mzone, (cuDoubleComplex*)A, lda,
-                 (cuDoubleComplex*)B, ldb,
-                 zone,  (cuDoubleComplex*)C, ldc );
+    cublasSetKernelStream(cuda_stream->cuda_stream);
+    cublasZgemm('N', dplasma_lapack_const(dplasmaConjTrans),
+                n, n, k,
+                mzone, (cuDoubleComplex *)A, lda,
+                (cuDoubleComplex *)B, ldb,
+                zone, (cuDoubleComplex *)C, ldc);
     status = cublasGetError();
-    PARSEC_CUDA_CHECK_ERROR( "cublasZgemm ", status,
-                             {return -1;} );
+    PARSEC_CUDA_CHECK_ERROR("cublasZgemm ", status,
+                            { return -1; });
     (void)gpu_device;
     return PARSEC_HOOK_RETURN_DONE;
 }
@@ -171,23 +171,23 @@ parsec_core_cuda_gemm(parsec_execution_stream_t *es, parsec_task_t *this_task)
                            &A, &lda, &B, &ldb, &beta, &C, &ldc);
 
     ratio = ((m + 1) - k);
-    dev_index = parsec_get_best_device((parsec_task_t *) this_task, ratio);
+    dev_index = parsec_get_best_device((parsec_task_t *)this_task, ratio);
     assert(dev_index >= 0);
-    if (dev_index < 2) {
+    if( dev_index < 2 ) {
         /* Fallback to the CPU only version */
         return parsec_core_gemm(es, this_task);
     }
 
-    gpu_task = (parsec_gpu_task_t *) calloc(1, sizeof(parsec_gpu_task_t));
+    gpu_task = (parsec_gpu_task_t *)calloc(1, sizeof(parsec_gpu_task_t));
     PARSEC_OBJ_CONSTRUCT(gpu_task, parsec_list_item_t);
-    gpu_task->ec = (parsec_task_t *) this_task;
+    gpu_task->ec = (parsec_task_t *)this_task;
     gpu_task->submit = &gpu_kernel_submit_dpotrf_U_potrf_dgemm;
     gpu_task->task_type = 0;
     gpu_task->load = ratio * parsec_device_sweight[dev_index];
-    gpu_task->last_data_check_epoch = -1;	/* force at least one validation for the task */
+    gpu_task->last_data_check_epoch = -1;    /* force at least one validation for the task */
     gpu_task->pushout = 0;
     gpu_task->flow[0] = NULL; /*&flow_of_dpotrf_U_potrf_dgemm_for_C;*/
-    if ((m == (k + 1))) {
+    if((m == (k + 1))) {
         gpu_task->pushout |= (1 << 0);
     }
     gpu_task->flow[1] = NULL;  /* &flow_of_dpotrf_U_potrf_dgemm_for_A; */
@@ -201,7 +201,7 @@ parsec_core_cuda_gemm(parsec_execution_stream_t *es, parsec_task_t *this_task)
 
 int main(int argc, char **argv)
 {
-    parsec_context_t* parsec;
+    parsec_context_t *parsec;
     int iparam[IPARAM_SIZEOF];
     int uplo = dplasmaUpper;
     int info = 0;
@@ -221,46 +221,54 @@ int main(int argc, char **argv)
     PASTE_CODE_IPARAM_LOCALS(iparam);
     PASTE_CODE_FLOPS(FLOPS_ZPOTRF, ((DagDouble_t)N));
 
+    int nbgpus = 0;
+#if defined(PARSEC_HAVE_CUDA)
+    for(int i = 0; i < (int)parsec_nb_devices; i++) {
+        parsec_device_module_t *dev = parsec_mca_device_get(i);
+        if(dev->type & PARSEC_DEV_CUDA)
+            nbgpus++;
+    }
+#endif
+
     /* initializing matrix structure */
-    LDA = dplasma_imax( LDA, N );
-    LDB = dplasma_imax( LDB, N );
+    LDA = dplasma_imax(LDA, N);
+    LDB = dplasma_imax(LDB, N);
     KP = 1;
     KQ = 1;
 
     PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
-        parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
-                                   rank, MB, NB, LDA, N, 0, 0,
-                                   N, N, P, nodes/P, uplo));
+                               parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
+                                                                rank, MB, NB, LDA, N, 0, 0,
+                                                                N, N, P, nodes / P, uplo));
 
     /* Initializing dc for dtd */
     parsec_matrix_sym_block_cyclic_t *__dcA = &dcA;
     parsec_dtd_data_collection_init((parsec_data_collection_t *)&dcA);
 
-    /* matrix generation */
-    if(loud > 3) printf("+++ Generate matrices ... ");
-    dplasma_zplghe( parsec, (double)(N), uplo,
-                    (parsec_tiled_matrix_t *)&dcA, random_seed);
-    if(loud > 3) printf("Done\n");
 
     /* Getting new parsec handle of dtd type */
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 
     /* Allocating data arrays to be used by comm engine */
     parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
-    dplasma_add2arena_tile( tile_full,
-                            dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
-                            PARSEC_ARENA_ALIGNMENT_SSE,
-                            parsec_datatype_double_complex_t, dcA.super.mb );
+    dplasma_add2arena_tile(tile_full,
+                           dcA.super.mb * dcA.super.nb * sizeof(dplasma_complex64_t),
+                           PARSEC_ARENA_ALIGNMENT_SSE,
+                           parsec_datatype_double_complex_t, dcA.super.mb);
 
-    /* Registering the handle with parsec context */
-    parsec_context_add_taskpool( parsec, dtd_tp );
+    for( int t = 0; t < nruns + 1; t++ ) {
+        /* matrix generation */
+        if( loud > 3 ) printf("+++ Generate matrices ... ");
+        dplasma_zplghe(parsec, (double)(N), uplo,
+                       (parsec_tiled_matrix_t *)&dcA, random_seed);
+        if( loud > 3 ) printf("Done\n");
 
-    SYNC_TIME_START();
+        /* Registering the handle with parsec context */
+        parsec_context_add_taskpool(parsec, dtd_tp);
 
-    /* #### parsec context Starting #### */
+        SYNC_TIME_START();
 
-    /* start parsec context */
-    parsec_context_start( parsec );
+        /* #### parsec context Starting #### */
 
     parsec_task_class_t *gemm_tc = parsec_dtd_create_task_class( dtd_tp, "Gemm",
                                             /* transA_g */ sizeof(int), PARSEC_VALUE,
@@ -461,29 +469,32 @@ int main(int argc, char **argv)
                                        PARSEC_DTD_EMPTY_FLAG,        &ldan,
                                        PARSEC_DTD_ARG_END );
                 }
-                parsec_dtd_data_flush( dtd_tp, PARSEC_DTD_TILE_OF(A, k, m) );
+            }
+
+            parsec_dtd_data_flush_all(dtd_tp, (parsec_data_collection_t *)&dcA);
+
+            /* finishing all the tasks inserted, but not finishing the handle */
+            parsec_dtd_taskpool_wait(dtd_tp);
+
+            /* Waiting on all handle and turning everything off for this context */
+            parsec_context_wait(parsec);
+
+            /* #### PaRSEC context is done #### */
+
+            if( t > 0 ) {
+                SYNC_TIME_PRINT(rank, ("\tPxQ= %3d %-3d NB= %4d N= %7d : %14f gflops\n",
+                                       P, Q, NB, N,
+                                       gflops = (flops / 1e9) / sync_time_elapsed));
+                gflops_avg += gflops / nruns;
             }
         }
     }
-
-    parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcA );
-
-    /* finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
-
-    /* Waiting on all handle and turning everything off for this context */
-    parsec_context_wait( parsec );
-
-    /* #### PaRSEC context is done #### */
-
-    SYNC_TIME_PRINT(rank, ("\tPxQ= %3d %-3d NB= %4d N= %7d : %14f gflops\n",
-                           P, Q, NB, N,
-                           gflops=(flops/1e9)/sync_time_elapsed));
+    PASTE_CODE_PERF_LOOP_DONE();
 
     parsec_dtd_task_class_release(dtd_tp, gemm_tc );
 
     /* Cleaning up the parsec handle */
-    parsec_taskpool_free( dtd_tp );
+    parsec_taskpool_free(dtd_tp);
 
     if( 0 == rank && info != 0 ) {
         printf("-- Factorization is suspicious (info = %d) ! \n", info);
@@ -492,55 +503,59 @@ int main(int argc, char **argv)
     if( !info && check ) {
         /* Check the factorization */
         PASTE_CODE_ALLOCATE_MATRIX(dcA0, check,
-            parsec_matrix_sym_block_cyclic, (&dcA0, PARSEC_MATRIX_COMPLEX_DOUBLE,
-                                       rank, MB, NB, LDA, N, 0, 0,
-                                       N, N, P, nodes/P, uplo));
-        dplasma_zplghe( parsec, (double)(N), uplo,
-                        (parsec_tiled_matrix_t *)&dcA0, random_seed);
+                                   parsec_matrix_sym_block_cyclic, (&dcA0, PARSEC_MATRIX_COMPLEX_DOUBLE,
+                                                                    rank, MB, NB, LDA, N, 0, 0,
+                                                                    N, N, P, nodes / P, uplo));
+        dplasma_zplghe(parsec, (double)(N), uplo,
+                       (parsec_tiled_matrix_t *)&dcA0, random_seed);
 
-        ret |= check_zpotrf( parsec, (rank == 0) ? loud : 0, uplo,
-                             (parsec_tiled_matrix_t *)&dcA,
-                             (parsec_tiled_matrix_t *)&dcA0);
+        ret |= check_zpotrf(parsec, (rank == 0) ? loud : 0, uplo,
+                            (parsec_tiled_matrix_t *)&dcA,
+                            (parsec_tiled_matrix_t *)&dcA0);
 
         /* Check the solution */
         PASTE_CODE_ALLOCATE_MATRIX(dcB, check,
-            parsec_matrix_block_cyclic, (&dcB, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
-                                   rank, MB, NB, LDB, NRHS, 0, 0,
-                                   N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, random_seed+1);
+                                   parsec_matrix_block_cyclic, (&dcB, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
+                                                                rank, MB, NB, LDB, NRHS, 0, 0,
+                                                                N, NRHS, P, nodes / P, KP, KQ, IP, JQ));
+        dplasma_zplrnt(parsec, 0, (parsec_tiled_matrix_t *)&dcB, random_seed + 1);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcX, check,
-            parsec_matrix_block_cyclic, (&dcX, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
-                                   rank, MB, NB, LDB, NRHS, 0, 0,
-                                   N, NRHS, P, nodes/P, KP, KQ, IP, JQ));
-        dplasma_zlacpy( parsec, dplasmaUpperLower,
-                        (parsec_tiled_matrix_t *)&dcB, (parsec_tiled_matrix_t *)&dcX );
+                                   parsec_matrix_block_cyclic, (&dcX, PARSEC_MATRIX_COMPLEX_DOUBLE, PARSEC_MATRIX_TILE,
+                                                                rank, MB, NB, LDB, NRHS, 0, 0,
+                                                                N, NRHS, P, nodes / P, KP, KQ, IP, JQ));
+        dplasma_zlacpy(parsec, dplasmaUpperLower,
+                       (parsec_tiled_matrix_t *)&dcB, (parsec_tiled_matrix_t *)&dcX);
 
         dplasma_zpotrs(parsec, uplo,
                        (parsec_tiled_matrix_t *)&dcA,
-                       (parsec_tiled_matrix_t *)&dcX );
+                       (parsec_tiled_matrix_t *)&dcX);
 
-        ret |= check_zaxmb( parsec, (rank == 0) ? loud : 0, uplo,
-                            (parsec_tiled_matrix_t *)&dcA0,
-                            (parsec_tiled_matrix_t *)&dcB,
-                            (parsec_tiled_matrix_t *)&dcX);
+        ret |= check_zaxmb(parsec, (rank == 0) ? loud : 0, uplo,
+                           (parsec_tiled_matrix_t *)&dcA0,
+                           (parsec_tiled_matrix_t *)&dcB,
+                           (parsec_tiled_matrix_t *)&dcX);
 
         /* Cleanup */
-        parsec_data_free(dcA0.mat); dcA0.mat = NULL;
-        parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA0 );
-        parsec_data_free(dcB.mat); dcB.mat = NULL;
-        parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcB );
-        parsec_data_free(dcX.mat); dcX.mat = NULL;
-        parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcX );
+        parsec_data_free(dcA0.mat);
+        dcA0.mat = NULL;
+        parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcA0);
+        parsec_data_free(dcB.mat);
+        dcB.mat = NULL;
+        parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcB);
+        parsec_data_free(dcX.mat);
+        dcX.mat = NULL;
+        parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcX);
     }
 
     /* Cleaning data arrays we allocated for communication */
-    dplasma_matrix_del2arena( tile_full );
+    dplasma_matrix_del2arena(tile_full);
     parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
-    parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
+    parsec_dtd_data_collection_fini((parsec_data_collection_t *)&dcA);
 
-    parsec_data_free(dcA.mat); dcA.mat = NULL;
-    parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);
+    parsec_data_free(dcA.mat);
+    dcA.mat = NULL;
+    parsec_tiled_matrix_destroy((parsec_tiled_matrix_t *)&dcA);
 
     cleanup_parsec(parsec, iparam);
     return ret;

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -116,6 +116,7 @@ gpu_kernel_submit_dpotrf_U_potrf_dgemm(parsec_device_gpu_module_t * gpu_device,
     dplasma_complex64_t *C;
     parsec_task_t *this_task = gpu_task->ec;
     parsec_cuda_exec_stream_t *cuda_stream = (parsec_cuda_exec_stream_t*)gpu_stream;
+    parsec_device_cuda_module_t *cuda_device = (parsec_device_cuda_module_t*)gpu_device;
 
     parsec_dtd_unpack_args(this_task, &transA, &transB, &m, &n, &k, &alpha,
                            &A, &lda, &B, &ldb, &beta, &C, &ldc);

--- a/tests/testing_zsymm.c
+++ b/tests/testing_zsymm.c
@@ -42,6 +42,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     LDB = max(LDB, M);
     LDC = max(LDC, M);
 
@@ -74,7 +76,7 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDA, Am, 0, 0,
                                        Am, Am, P, nodes/P, uplo));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if (loud > 2) printf("Generate matrices ... ");
             dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
@@ -90,7 +92,7 @@ int main(int argc, char ** argv)
                                               beta,  (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zsymm, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsymm);
 
             dplasma_zsymm_Destruct( PARSEC_zsymm );
         }

--- a/tests/testing_zsyr2k.c
+++ b/tests/testing_zsyr2k.c
@@ -71,24 +71,27 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
-        dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB,  Bseed);
+            dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        /* Create PaRSEC */
-        PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyr2k,
-                                  (uplo, trans,
-                                   alpha, (parsec_tiled_matrix_t *)&dcA,
-                                          (parsec_tiled_matrix_t *)&dcB,
-                                   beta,  (parsec_tiled_matrix_t *)&dcC));
+            /* Create PaRSEC */
+            PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyr2k,
+                                      (uplo, trans,
+                                              alpha, (parsec_tiled_matrix_t *)&dcA,
+                                              (parsec_tiled_matrix_t *)&dcB,
+                                              beta,  (parsec_tiled_matrix_t *)&dcC));
 
-        /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zsyr2k);
+            /* lets rock! */
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyr2k, t);
 
-        dplasma_zsyr2k_Destruct( PARSEC_zsyr2k );
+            dplasma_zsyr2k_Destruct( PARSEC_zsyr2k );
+        }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);

--- a/tests/testing_zsyr2k.c
+++ b/tests/testing_zsyr2k.c
@@ -42,6 +42,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     M = N;
     LDC = dplasma_imax(LDC, N);
 
@@ -71,7 +73,7 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
@@ -87,7 +89,7 @@ int main(int argc, char ** argv)
                                               beta,  (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyr2k, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyr2k);
 
             dplasma_zsyr2k_Destruct( PARSEC_zsyr2k );
         }

--- a/tests/testing_zsyrk.c
+++ b/tests/testing_zsyrk.c
@@ -35,6 +35,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     M = N;
     LDC = max(LDC, N);
 
@@ -58,7 +60,7 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
@@ -72,7 +74,7 @@ int main(int argc, char ** argv)
                                               beta,  (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyrk, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyrk);
 
             dplasma_zsyrk_Destruct( PARSEC_zsyrk );
         }

--- a/tests/testing_zsyrk.c
+++ b/tests/testing_zsyrk.c
@@ -58,22 +58,25 @@ int main(int argc, char ** argv)
                                        rank, MB, NB, LDC, N, 0, 0,
                                        N, N, P, nodes/P, uplo));
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
-        dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA,  Aseed);
+            dplasma_zplgsy( parsec, 0., uplo, (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        /* Create PaRSEC */
-        PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyrk,
-                                  (uplo, trans,
-                                   alpha, (parsec_tiled_matrix_t *)&dcA,
-                                   beta,  (parsec_tiled_matrix_t *)&dcC));
+            /* Create PaRSEC */
+            PASTE_CODE_ENQUEUE_KERNEL(parsec, zsyrk,
+                                      (uplo, trans,
+                                              alpha, (parsec_tiled_matrix_t *)&dcA,
+                                              beta,  (parsec_tiled_matrix_t *)&dcC));
 
-        /* lets rock! */
-        PASTE_CODE_PROGRESS_KERNEL(parsec, zsyrk);
+            /* lets rock! */
+            PASTE_CODE_PROGRESS_KERNEL(parsec, zsyrk, t);
 
-        dplasma_zsyrk_Destruct( PARSEC_zsyrk );
+            dplasma_zsyrk_Destruct( PARSEC_zsyrk );
+        }
+        PASTE_CODE_PERF_LOOP_DONE();
 
         parsec_data_free(dcA.mat);
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);

--- a/tests/testing_ztrmm.c
+++ b/tests/testing_ztrmm.c
@@ -68,24 +68,24 @@ int main(int argc, char ** argv)
             dcA = parsec_tiled_matrix_submatrix( (parsec_tiled_matrix_t *)&dcA0, 0, 0, N, N );
         }
 
-        /* matrix generation */
-        if(loud > 2) printf("+++ Generate matrices ... ");
-        dplasma_zplghe( parsec, 0., uplo, dcA, Aseed);
-        dplasma_zplrnt( parsec, 0,        (parsec_tiled_matrix_t *)&dcC, Cseed);
-        if(loud > 2) printf("Done\n");
+        for(int t = 0; t < nruns+1; t++) {
+            /* matrix generation */
+            if(loud > 2) printf("+++ Generate matrices ... ");
+            dplasma_zplghe( parsec, 0., uplo, dcA, Aseed);
+            dplasma_zplrnt( parsec, 0,        (parsec_tiled_matrix_t *)&dcC, Cseed);
+            if(loud > 2) printf("Done\n");
 
-        int t;
-        for(t = 0; t < nruns; t++) {
             parsec_devices_release_memory();
             /* Create PaRSEC */
             PASTE_CODE_ENQUEUE_PROGRESS_DESTRUCT_KERNEL(parsec, ztrmm,
-                                      (side, uplo, trans, diag,
-                                       1.0, dcA,
-                                       (parsec_tiled_matrix_t *)&dcC),
-                                      dplasma_ztrmm_Destruct( PARSEC_ztrmm ));
+                                                        (side, uplo, trans, diag,
+                                                                1.0, dcA,
+                                                                (parsec_tiled_matrix_t *)&dcC),
+                                                                dplasma_ztrmm_Destruct( PARSEC_ztrmm ), t);
 
             parsec_devices_reset_load(parsec);
         }
+        PASTE_CODE_PERF_LOOP_DONE();
         free(dcA);
     }
     else

--- a/tests/testing_ztrmm.c
+++ b/tests/testing_ztrmm.c
@@ -39,6 +39,9 @@ int main(int argc, char ** argv)
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
+
+    dplasma_warmup(parsec);
+
     /* initializing matrix structure */
     int Am = max(M, N);
     LDA = max(LDA, Am);
@@ -68,7 +71,7 @@ int main(int argc, char ** argv)
             dcA = parsec_tiled_matrix_submatrix( (parsec_tiled_matrix_t *)&dcA0, 0, 0, N, N );
         }
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             dplasma_zplghe( parsec, 0., uplo, dcA, Aseed);
@@ -81,7 +84,7 @@ int main(int argc, char ** argv)
                                                         (side, uplo, trans, diag,
                                                                 1.0, dcA,
                                                                 (parsec_tiled_matrix_t *)&dcC),
-                                                                dplasma_ztrmm_Destruct( PARSEC_ztrmm ), t);
+                                                                dplasma_ztrmm_Destruct( PARSEC_ztrmm ));
 
             parsec_devices_reset_load(parsec);
         }

--- a/tests/testing_ztrsm.c
+++ b/tests/testing_ztrsm.c
@@ -36,6 +36,9 @@ int main(int argc, char ** argv)
     /* Initialize PaRSEC */
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
+
+    dplasma_warmup(parsec);
+
     /* initializing matrix structure */
     int Am = dplasma_imax(M, N);
     LDA = dplasma_imax(LDA, Am);
@@ -62,7 +65,7 @@ int main(int argc, char ** argv)
 
         PASTE_CODE_FLOPS(FLOPS_ZTRSM, (side, (DagDouble_t)M, (DagDouble_t)N));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             /* Generate matrix A with diagonal dominance to keep stability during computation */
@@ -94,7 +97,7 @@ int main(int argc, char ** argv)
                                               dcA, (parsec_tiled_matrix_t *)&dcC));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, ztrsm, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, ztrsm);
 
             dplasma_ztrsm_Destruct( PARSEC_ztrsm );
         }

--- a/tests/testing_ztrtri.c
+++ b/tests/testing_ztrtri.c
@@ -31,6 +31,8 @@ int main(int argc, char ** argv)
     parsec = setup_parsec(argc, argv, iparam);
     PASTE_CODE_IPARAM_LOCALS(iparam);
 
+    dplasma_warmup(parsec);
+
     /* initializing matrix structure */
     int Am = dplasma_imax(M, N);
 
@@ -54,7 +56,7 @@ int main(int argc, char ** argv)
 
         PASTE_CODE_FLOPS(FLOPS_ZTRTRI, ((DagDouble_t)Am));
 
-        for(int t = 0; t < nruns+1; t++) {
+        for(int t = 0; t < nruns; t++) {
             /* matrix generation */
             if(loud > 2) printf("+++ Generate matrices ... ");
             /* Generate matrix A with diagonal dominance to keep stability during computation */
@@ -70,7 +72,7 @@ int main(int argc, char ** argv)
                                       (uplo, diag, (parsec_tiled_matrix_t *)&dcA, &info));
 
             /* lets rock! */
-            PASTE_CODE_PROGRESS_KERNEL(parsec, ztrtri, t);
+            PASTE_CODE_PROGRESS_KERNEL(parsec, ztrtri);
 
             dplasma_ztrtri_Destruct( PARSEC_ztrtri );
         }


### PR DESCRIPTION
PR based on 
https://bitbucket.org/icldistcomp/dplasma/pull-requests/88
https://bitbucket.org/icldistcomp/dplasma/pull-requests/89

For all DPLASMA testing drivers that support timing, add support for the --nruns option (defaults to 3 timed run per execution) with warmup loop iteration.

-x forces --nruns to be 0, meaning only the warmup run (without timing information displayed) is executed to prepare the matrices to check.

Each dpalsma tester does nruns+1 iterations of the main operation (sometimes hard to define for operations that involve multiple DAGs, in this case, each is done nruns+1 times), and only the last nruns timing are displayed, to remove artefacts like the cost of initializing the mathematical library.

This patch also introduces some fixes in a few benchmarks (zheev, the CUDA-enabled DTD that did not manage the case where CUDA is compiled-in but there is no CUDA device available, and a few other issues).