### PR TITLE
Missing include in cmake fortran compiler flag checker

### DIFF
--- a/cmake_modules/DplasmaCompilerFlags.cmake
+++ b/cmake_modules/DplasmaCompilerFlags.cmake
@@ -1,4 +1,5 @@
 include (CheckCCompilerFlag)
+include (CheckFortranCompilerFlag)
 
 #
 # This is a convenience function that will check a given option


### PR DESCRIPTION
Signed-off-by: Aurélien Bouteiller <bouteill@icl.utk.edu>