### PR TITLE
Protect accesses to the data info and arena.

### DIFF
--- a/src/dplasmajdf_lapack_dtt.h
+++ b/src/dplasmajdf_lapack_dtt.h
@@ -21,27 +21,27 @@ static inline
 int LDA_internal(const dplasma_data_collection_t *ddc, parsec_data_copy_t *cp)
 {
     int rc;
-    lapack_info_t info;
-    parsec_arena_datatype_t *adt;
+    const lapack_info_t *info;
+    const parsec_arena_datatype_t *adt;
     (void)rc;
     /* obtain the lda of this dc->dtt */
     rc = dplasma_get_info_from_datatype(ddc, cp->dtt, &info, &adt);
     assert(rc == 0);
     PARSEC_DEBUG_VERBOSE(4, parsec_debug_output,
-        "CP %p [%p] [type %p] lda %d", cp, cp->device_private, cp->dtt, info.lda);
-    return info.lda;
+        "CP %p [%p] [type %p] lda %d", cp, cp->device_private, cp->dtt, info->lda);
+    return info->lda;
 }
 #define LDA(ddc, FLOW_NAME)\
     LDA_internal(ddc, _f_##FLOW_NAME)
 
 /* Obtain the appropriate parsec_arena_datatype_t for a given location and shape in the datacollection
  */
-static inline
-parsec_arena_datatype_t* ADTT_DC(const dplasma_data_collection_t *ddc, int loc, int target_shape, int target_layout)
+static inline const parsec_arena_datatype_t*
+ADTT_DC(const dplasma_data_collection_t *ddc, int loc, int target_shape, int target_layout)
 {
     int rc;
     lapack_info_t info;
-    parsec_arena_datatype_t *adt;
+    const parsec_arena_datatype_t *adt;
     (void)rc;
 
     info.loc = loc;
@@ -60,15 +60,15 @@ parsec_arena_datatype_t* ADTT_DC(const dplasma_data_collection_t *ddc, int loc, 
 /* Obtain the appropriate parsec_arena_datatype_t that represents the type of the datacopy with the given shape
  */
 static parsec_arena_datatype_t adt_null_dc;
-static inline
-parsec_arena_datatype_t* ADTT_CP(parsec_data_copy_t *cp, const dplasma_data_collection_t *ddc, int target_loc, int target_shape)
+static inline const parsec_arena_datatype_t*
+ADTT_CP(parsec_data_copy_t *cp, const dplasma_data_collection_t *ddc, int target_loc, int target_shape)
 {
+    const parsec_arena_datatype_t *adt;
+    const lapack_info_t* cp_info;
     int rc;
-    lapack_info_t info;
-    parsec_arena_datatype_t *adt;
     (void)rc;
 
-    if(cp == NULL){
+    if(cp == NULL) {
       /* this flow is not actually originating an output dep */
       /* this case happens because the JDF generated code obtains the ADT before
        * evaluating the guards for the successors during iterate successors.
@@ -77,24 +77,26 @@ parsec_arena_datatype_t* ADTT_CP(parsec_data_copy_t *cp, const dplasma_data_coll
     }
 
     /* obtain the location & layout of this dc->dtt */
-    rc = dplasma_get_info_from_datatype(ddc, cp->dtt, &info, &adt);
+    rc = dplasma_get_info_from_datatype(ddc, cp->dtt, &cp_info, &adt);
     assert(rc == 0);
 
-    if(( info.shape == target_shape )||(target_shape == SAME)){
+    if(( cp_info->shape == target_shape )||(target_shape == SAME)){
       PARSEC_DEBUG_VERBOSE(8, parsec_debug_output,
-        "CP %p [type %p] -> target_shape %d target_loc %d dtt %p",
-         cp, cp->dtt, target_shape, target_loc, adt->opaque_dtt);
+                           "CP %p [type %p] -> target_shape %d target_loc %d dtt %p",
+                            cp, cp->dtt, target_shape, target_loc, adt->opaque_dtt);
       return adt;
     }
 
+    /* make a copy of the info, don't alter the one currently in the hash table */
+    lapack_info_t info = *cp_info;
     info.loc = target_loc;
     info.shape = target_shape;
     /* obtain the equivalent dtt for the same location with the target_shape */
     rc = dplasma_get_datatype_from_info(ddc, &info, &adt);
     assert(rc == 0);
     PARSEC_DEBUG_VERBOSE(8, parsec_debug_output,
-        "CP %p [type %p] loc %d layout %d -> dtt %p target_shape %d",
-         cp, cp->dtt, target_loc, info.layout, adt->opaque_dtt, target_shape);
+                         "CP %p [type %p] loc %d layout %d -> dtt %p target_shape %d",
+                          cp, cp->dtt, target_loc, info.layout, adt->opaque_dtt, target_shape);
     return adt;
 }
 
@@ -103,16 +105,16 @@ static inline
 void ADTT_INFO_internal(parsec_data_copy_t *cp, const dplasma_data_collection_t *ddc, int *lda, int *rows, int *cols)
 {
     int rc;
-    lapack_info_t info;
-    parsec_arena_datatype_t *adt;
+    const lapack_info_t* info;
+    const parsec_arena_datatype_t *adt;
     (void)rc;
     assert(cp != NULL);
     /* obtain the location & layout of this dc->dtt */
     rc = dplasma_get_info_from_datatype(ddc, cp->dtt, &info, &adt);
     assert(rc == 0);
-    *lda = info.lda;
-    *rows = info.rows;
-    *cols = info.cols;
+    *lda = info->lda;
+    *rows = info->rows;
+    *cols = info->cols;
 }
 
 #define ADTT_INFO(ddc, FLOW_NAME, lda, rows, cols)\

--- a/src/include/dplasma/types_lapack.h
+++ b/src/include/dplasma/types_lapack.h
@@ -193,7 +193,13 @@ void dplasma_clean_adtt_all_loc(const dplasma_data_collection_t * ddc, int max_s
                 if ( dplasma_cleanup_datatype_info(ddc, &info, &adt) == 0) {
                     /* Retained when reusing it, not set on JDF array, not release by taskpool destructor */
                     PARSEC_OBJ_RELEASE(adt.arena);
-                    dplasma_matrix_del2arena(&adt);
+                    /* A datatype being registered with multiple info we should
+                     * only release the datatype once all info have been
+                     * removed. We can track this using the refcount on the
+                     * arena itself.
+                     */
+                    if( NULL == adt.arena )
+                        dplasma_matrix_del2arena(&adt);
                 }
             }
         }

--- a/src/include/dplasma/types_lapack.h
+++ b/src/include/dplasma/types_lapack.h
@@ -68,21 +68,21 @@ void dplasma_setup_adtt_loc(dplasma_data_collection_t * ddc,
     info.shape = shape;
     info.layout = layout;
 
-    if ( (adt_default != NULL) && (full_rows == rows) && (full_cols == cols) ){
+    if ( (adt_default != NULL) && (full_rows == rows) && (full_cols == cols) ) {
         /* Reuse external datatype */
         /* Reuse arena through dplasma reuse, otherwise we don't know how to release
          * during destruct.
          */
         PARSEC_OBJ_RETAIN(adt_default->arena);
-        dplasma_set_datatype_info(ddc, *adt_default, info);
-    }else{
+        dplasma_set_datatype_info(ddc, *adt_default, &info);
+    } else {
         /* Reuse dplasma arena & datatype */
         dplasma_get_or_construct_adt(&adt, parsec_type,
                                      PARSEC_ARENA_ALIGNMENT_SSE,
                                      uplo, diag,
                                      rows, cols, ld,
                                      -1/* resized = -1 for all dplasma types */);
-        dplasma_set_datatype_info(ddc, adt, info);
+        dplasma_set_datatype_info(ddc, adt, &info);
     }
 }
 
@@ -190,10 +190,10 @@ void dplasma_clean_adtt_all_loc(const dplasma_data_collection_t * ddc, int max_s
                 info.loc = loc;
                 info.shape = shape;
                 info.layout = layout;
-                if ( dplasma_cleanup_datatype_info(ddc, info, &adt) == 0){
+                if ( dplasma_cleanup_datatype_info(ddc, &info, &adt) == 0) {
                     /* Retained when reusing it, not set on JDF array, not release by taskpool destructor */
                     PARSEC_OBJ_RELEASE(adt.arena);
-                    dplasma_matrix_del2arena( &adt);
+                    dplasma_matrix_del2arena(&adt);
                 }
             }
         }

--- a/src/utils/dplasma_arena_datatype.h
+++ b/src/utils/dplasma_arena_datatype.h
@@ -11,7 +11,7 @@
 #include "parsec/arena.h"
 #include "parsec/class/parsec_hash_table.h"
 
-#define REUSE_ARENA_DATATYPE
+#undef REUSE_ARENA_DATATYPE
 #define DATATYPE_KEY_STR_SZ 100
 
 extern parsec_hash_table_t *dplasma_arenas;

--- a/src/utils/dplasma_lapack_adtt.c
+++ b/src/utils/dplasma_lapack_adtt.c
@@ -59,8 +59,10 @@ static void dplasma_datatypes_info_fini()
     }
 }
 
-static int dplasma_set_dtt_to_info( const dplasma_data_collection_t *dc, parsec_arena_datatype_t adt,
-                                    lapack_info_t info)
+static int
+dplasma_set_dtt_to_info( const dplasma_data_collection_t *dc,
+                         parsec_arena_datatype_t adt,
+                         const lapack_info_t* info)
 {
     dplasma_datatype_lapack_helper_t * dtt_entry = NULL;
 
@@ -76,57 +78,69 @@ static int dplasma_set_dtt_to_info( const dplasma_data_collection_t *dc, parsec_
     } else {
         dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
         if( NULL != dtt_entry ) {
-            assert(dtt_entry->info.lda == info.lda);
+            assert(dtt_entry->info.lda == info->lda);
             return 0;
         }
     }
 
     dtt_entry = (dplasma_datatype_lapack_helper_t *)malloc(sizeof(dplasma_datatype_lapack_helper_t));
     dtt_entry->ht_item.key = (uint64_t)strdup(static_desc);
-    dtt_entry->info = info;
+    dtt_entry->info = *info;
     dtt_entry->adt = adt;
     parsec_hash_table_nolock_insert(dplasma_datatypes_lapack_helper, &dtt_entry->ht_item);
     PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
-        " insert dtt -> info lda %d rows %d cols %d loc %d shape %d layout %d dtt %"PRIxPTR" arena %p (%30s)",
-        info.lda, info.rows, info.cols, info.loc, info.shape, info.layout, (intptr_t)adt.opaque_dtt, adt.arena, static_desc);
+        " insert dtt -> info lda %d rows %d cols %d loc %d shape %d layout %d dtt %p arena %p (%30s)",
+        info->lda, info->rows, info->cols, info->loc, info->shape, info->layout, adt->opaque_dtt, adt->arena, static_desc);
     return 0;
 }
 
-static int dplasma_set_info_to_dtt( const dplasma_data_collection_t *dc, parsec_arena_datatype_t adt,
-                                    lapack_info_t info)
+static int
+dplasma_set_info_to_dtt( const dplasma_data_collection_t *dc,
+                         parsec_arena_datatype_t adt,
+                         const lapack_info_t* info)
 {
     dplasma_datatype_lapack_helper_t * dtt_entry = NULL;
 
     char static_desc[LAPACK_ADT_KEY_STR_SZ];
-    snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|-1|%d|%d|%d", dc, info.loc, info.shape, info.layout);
+    snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|-1|%d|%d|%d", dc, info->loc, info->shape, info->layout);
     parsec_key_t k = (uint64_t)static_desc;
     if( NULL == dplasma_datatypes_lapack_helper ) {
-        dplasma_datatypes_lapack_helper = PARSEC_OBJ_NEW(parsec_hash_table_t);
-        parsec_hash_table_init(dplasma_datatypes_lapack_helper,
+        parsec_hash_table_t* new_ht = PARSEC_OBJ_NEW(parsec_hash_table_t);
+        parsec_hash_table_init(new_ht,
                                offsetof(dplasma_datatype_lapack_helper_t, ht_item),
                                16, dtt_lapack_key_fns, NULL);
-        parsec_context_at_fini(dplasma_datatypes_info_fini, NULL);
-    } else {
-        dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
-        if( NULL != dtt_entry ) {
-            assert(dtt_entry->adt.opaque_dtt == adt.opaque_dtt);
-            return 0;
+        if(parsec_atomic_cas_ptr(&dplasma_datatypes_lapack_helper, NULL, new_ht)) {
+            parsec_context_at_fini(dplasma_datatypes_info_fini, NULL);
+        } else {
+             parsec_hash_table_fini(new_ht);
+             PARSEC_OBJ_RELEASE(new_ht);
         }
+    }
+
+    parsec_hash_table_lock_bucket(dplasma_datatypes_lapack_helper, k);  /* protect access to the hash table */
+    /* Find the entry */
+    dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
+    if( NULL != dtt_entry ) {
+        assert(dtt_entry->adt.opaque_dtt == adt.opaque_dtt);
+        parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);
+        return 0;
     }
 
     dtt_entry = (dplasma_datatype_lapack_helper_t *)malloc(sizeof(dplasma_datatype_lapack_helper_t));
     dtt_entry->ht_item.key = (uint64_t)strdup(static_desc);
-    dtt_entry->info = info;
+    dtt_entry->info = *info;
     dtt_entry->adt = adt;
     parsec_hash_table_nolock_insert(dplasma_datatypes_lapack_helper, &dtt_entry->ht_item);
+    parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);
     PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
-        " insert dtt <- info lda %d rows %d cols %d loc %d shape %d layout %d dtt %"PRIxPTR" arena %p (%30s)",
-        info.lda, info.rows, info.cols, info.loc, info.shape, info.layout, (intptr_t)adt.opaque_dtt, adt.arena, static_desc);
+        " insert dtt <- info lda %d rows %d cols %d loc %d shape %d layout %d dtt %p arena %p (%30s)",
+        info->lda, info->rows, info->cols, info->loc, info->shape, info->layout, adt->opaque_dtt, adt->arena, static_desc);
     return 0;
 }
 
-int dplasma_set_datatype_info( const dplasma_data_collection_t *dc, parsec_arena_datatype_t adt,
-                               lapack_info_t info)
+int dplasma_set_datatype_info( const dplasma_data_collection_t *dc,
+                               parsec_arena_datatype_t adt,
+                               const lapack_info_t* info)
 {
     dplasma_set_dtt_to_info(dc, adt, info);
     dplasma_set_info_to_dtt(dc, adt, info);
@@ -134,58 +148,67 @@ int dplasma_set_datatype_info( const dplasma_data_collection_t *dc, parsec_arena
 }
 
 int dplasma_get_info_from_datatype( const dplasma_data_collection_t *dc, parsec_datatype_t dtt,
-                                    lapack_info_t *info,
-                                    parsec_arena_datatype_t **adt)
+                                    const lapack_info_t **info,
+                                    const parsec_arena_datatype_t **adt)
 {
     dplasma_datatype_lapack_helper_t * dtt_entry = NULL;
     char static_desc[LAPACK_ADT_KEY_STR_SZ];
     snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|%"PRIxPTR"|-1|-1|-1", dc, (intptr_t)dtt);
     parsec_key_t k = (uint64_t)static_desc;
     assert(dplasma_datatypes_lapack_helper!= NULL);
+    parsec_hash_table_lock_bucket(dplasma_datatypes_lapack_helper, k);  /* protect access to the hash table */
     dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
     assert(dtt_entry != NULL);
-    *info = dtt_entry->info;
+    *info = &dtt_entry->info;
     *adt  = &dtt_entry->adt;
+    parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);
     return 0;
 }
 
 int dplasma_get_datatype_from_info( const dplasma_data_collection_t *dc,
                                     lapack_info_t *info,
-                                    parsec_arena_datatype_t **adt)
+                                    const parsec_arena_datatype_t **adt)
 {
     dplasma_datatype_lapack_helper_t * dtt_entry = NULL;
     char static_desc[LAPACK_ADT_KEY_STR_SZ];
     snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|-1|%d|%d|%d", dc, info->loc, info->shape, info->layout);
     parsec_key_t k = (uint64_t)static_desc;
     assert(dplasma_datatypes_lapack_helper!= NULL);
+    parsec_hash_table_lock_bucket(dplasma_datatypes_lapack_helper, k);  /* protect access to the hash table */
     dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
     assert(dtt_entry != NULL);
     *info = dtt_entry->info;
     *adt = &dtt_entry->adt;
+    parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);
     return 0;
 }
 
 int dplasma_cleanup_datatype_info( const dplasma_data_collection_t *dc,
-                                   lapack_info_t info,
+                                   const lapack_info_t* info,
                                    parsec_arena_datatype_t *adt)
 {
     dplasma_datatype_lapack_helper_t * dtt_entry = NULL;
     char static_desc[LAPACK_ADT_KEY_STR_SZ];
     parsec_key_t k;
+
     assert(dplasma_datatypes_lapack_helper!= NULL);
+
     /* Remove the two entries from the hash table */
-    snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|-1|%d|%d|%d", dc, info.loc, info.shape, info.layout);
+    snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|-1|%d|%d|%d", dc, info->loc, info->shape, info->layout);
     k = (uint64_t)static_desc;
+    parsec_hash_table_lock_bucket(dplasma_datatypes_lapack_helper, k);  /* protect access to the info bucket */
     dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
     if(dtt_entry != NULL) {
         *adt = dtt_entry->adt;
         PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
             " remove dtt <- info lda %d rows %d cols %d loc %d shape %d layout %d dtt %p arena %p (%30s)",
-            info.lda, info.rows, info.cols, info.loc, info.shape, info.layout, adt->opaque_dtt, adt->arena, static_desc);
+            info->lda, info->rows, info->cols, info->loc, info->shape, info->layout, adt->opaque_dtt, adt->arena, static_desc);
         dplasma_datatypes_lapack_helper_release((void*)dtt_entry, NULL);
+        parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);  /* release the loc on the info bucket */
 
         snprintf( static_desc, LAPACK_ADT_KEY_STR_SZ, "%p|%"PRIxPTR"|-1|-1|-1", dc, (intptr_t)adt->opaque_dtt);
         k = (uint64_t)static_desc;
+        parsec_hash_table_lock_bucket(dplasma_datatypes_lapack_helper, k);  /* protect access to the datatype bucket */
         dtt_entry = (dplasma_datatype_lapack_helper_t *)parsec_hash_table_nolock_find(dplasma_datatypes_lapack_helper, k);
         if(dtt_entry != NULL){ /* same desc + dtt can be reuse for several loc & shape */
             PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
@@ -194,15 +217,17 @@ int dplasma_cleanup_datatype_info( const dplasma_data_collection_t *dc,
                 (intptr_t)adt->opaque_dtt, adt->arena, static_desc);
             dplasma_datatypes_lapack_helper_release((void*)dtt_entry, NULL);
         }
+        parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);  /* release the lock on the datatype bucket */
         return 0;
     }
+    parsec_hash_table_unlock_bucket(dplasma_datatypes_lapack_helper, k);  /* release the lock on the info bucket */
     /* No found */
     return -1;
 }
 
 
 /***************************************************************************/
-/* Management of dplasma_data_collection_t to wrap parsec_datacollecctions */
+/* Management of dplasma_data_collection_t to wrap parsec_data_collection  */
 /***************************************************************************/
 
 static parsec_data_t* data_of(parsec_data_collection_t *desc, ...)
@@ -224,42 +249,27 @@ static parsec_data_t* data_of(parsec_data_collection_t *desc, ...)
     /* Correct datatype if not default because of location */
     int loc = dplasma_tile_location( ddc->dc_original, m, n);
 
-    // if(loc != DFULL_T){
-    //     lapack_info_t info;
-    //     parsec_arena_datatype_t *adt;
-    //     /* obtain the shape */
-    //     rc = dplasma_get_info_from_datatype(ddc->dc_original, cp->dtt, &info, &adt);
-    //     assert(rc == 0);
-    //     /* obtain appropriate dtt for that location, shape and layout */
-    //     info.loc = loc;
-    //     rc = dplasma_get_datatype_from_info(ddc->dc_original, &info, &adt);
-    //     assert(rc == 0);
+    const lapack_info_t *cp_info;
+    const parsec_arena_datatype_t *adt;
 
-    //     PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
-    //          "data_of CP %p [old type %p] loc %d -> dtt %p target_shape %d layout %d",
-    //          cp, cp->dtt, loc, adt->opaque_dtt, info.shape, info.layout);
-    //     parsec_data_create_with_type( dt->dc,
-    //                                   dt->key, cp->device_private, dt->nb_elts,
-    //                                   adt->opaque_dtt);
-    // }
-    // return dt;
-
-    lapack_info_t info;
-    parsec_arena_datatype_t *adt;
-    /* obtain the shape */
-    rc = dplasma_get_info_from_datatype(ddc, cp->dtt, &info, &adt);
+    /* obtain the shape of the original copy (aka device[0]) */
+    rc = dplasma_get_info_from_datatype(ddc, cp->dtt, &cp_info, &adt);
     assert(rc == 0);
-    /* obtain appropriate dtt for that location, shape and layout */
-    info.loc = loc;
-    rc = dplasma_get_datatype_from_info(ddc, &info, &adt);
-    assert(rc == 0);
-    if(cp->dtt != adt->opaque_dtt){
-        PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
-            "data_of CP %p [old type %"PRIxPTR"] loc %d -> dtt %"PRIxPTR" target_shape %d layout %d",
-            cp, (intptr_t)cp->dtt, loc, (intptr_t)adt->opaque_dtt, info.shape, info.layout);
-        dt = parsec_data_create_with_type( dt->dc,
-                                           dt->key, cp->device_private, dt->nb_elts,
-                                           adt->opaque_dtt);
+    if( loc != cp_info->loc ) {  /* if we are looking for a different shape/location */
+        /* obtain appropriate dtt for that location, shape and layout */
+        /* make a copy of the info, don't alter the one currently in the hash table */
+        lapack_info_t info = *cp_info;
+        info.loc = loc;
+        rc = dplasma_get_datatype_from_info(ddc, &info, &adt);
+        assert(rc == 0);
+        if(cp->dtt != adt->opaque_dtt){
+            PARSEC_DEBUG_VERBOSE(27, parsec_debug_output,
+                "data_of CP %p [old type %p] loc %d -> dtt %p target_shape %d layout %d",
+                cp, cp->dtt, loc, adt->opaque_dtt, info.shape, info.layout);
+            dt = parsec_data_create_with_type( dt->dc,
+                                               dt->key, cp->device_private, dt->nb_elts,
+                                               adt->opaque_dtt);
+        }
     }
 
     return dt;

--- a/src/utils/dplasma_lapack_adtt.h
+++ b/src/utils/dplasma_lapack_adtt.h
@@ -71,16 +71,20 @@ struct dplasma_datatype_lapack_helper_s {
 };
 typedef struct dplasma_datatype_lapack_helper_s dplasma_datatype_lapack_helper_t;
 
-int dplasma_set_datatype_info( const dplasma_data_collection_t *dc, parsec_arena_datatype_t adt,
-                               lapack_info_t info);
+int dplasma_set_datatype_info( const dplasma_data_collection_t *dc,
+                               parsec_arena_datatype_t adt,
+                               const lapack_info_t* info);
 
 int dplasma_get_info_from_datatype( const dplasma_data_collection_t *dc, parsec_datatype_t dtt,
-                                    lapack_info_t *info, parsec_arena_datatype_t **adt);
+                                    const lapack_info_t **info,
+                                    const parsec_arena_datatype_t **adt);
 int dplasma_get_datatype_from_info( const dplasma_data_collection_t *dc,
-                                    lapack_info_t *info, parsec_arena_datatype_t **adt);
+                                    lapack_info_t *info,
+                                    const parsec_arena_datatype_t **adt);
 
 int dplasma_cleanup_datatype_info( const dplasma_data_collection_t *dc,
-                                   lapack_info_t info, parsec_arena_datatype_t *adt);
+                                   const lapack_info_t* info,
+                                   parsec_arena_datatype_t *adt);
 
 /***************************************************************************/
 /* Management of dplasma_data_collection_t to wrap parsec_datacollections */


### PR DESCRIPTION
This is a first step toward protecting access to the arena info hash
table, the one allowing us to correctly reuse datatypes and their arena.
While this patch should work, it might be overly costly, as all accesses
are now protected, and I don't think we need this. Indeed, the arena are
build during the creation of a taskpool, so by the time any of the
threads are using them, they exist for a long time. Thus, the only
portion we need to protect is when multiple threads, mostly in the
context of recursive calls are creating new taskpool for submatrices,
and they create types that can be reused.

Signed-off-by: George Bosilca <bosilca@icl.utk.edu>