### PR TITLE
Warmup demonstration for POTRF

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(JDF
   zlaswp.jdf
   zpltmg_chebvand.jdf zpltmg_fiedler.jdf zpltmg_hankel.jdf zpltmg_toeppd.jdf
   zprint.jdf
+  zwarmup.jdf
   #
   # BLAS Level 3
   #
@@ -128,6 +129,7 @@ set(SOURCES
   zpltmg_wrapper.c
   zlatms_wrapper.c
   zprint_wrapper.c
+  zwarmup_wrapper.c
   # Level 3 Blas
   zgemm_wrapper.c
   zhemm_wrapper.c

--- a/src/zwarmup.jdf
+++ b/src/zwarmup.jdf
@@ -1,0 +1,58 @@
+extern "C" %{
+/*
+ * Copyright (c) 2022-     The University of Tennessee and The University
+ *                         of Tennessee Research Foundation. All rights
+ *                         reserved.
+ *
+ * @precisions normal z -> s d c
+ * $COPYRIGHT
+ *
+ */
+#include "dplasmajdf.h"
+#include "dplasmaaux.h"
+#include "parsec/data_dist/matrix/matrix.h"
+#include "parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic.h"
+#include "utils/dplasma_lapack_adtt.h"
+
+%}
+
+/*
+ * Globals
+ */
+
+ddescA     [type = "dplasma_data_collection_t*"]
+descA      [type = "parsec_tiled_matrix_t*" hidden = on default = "((dplasma_data_collection_t*)ddescA)->dc_original" aligned=ddescA]
+descAs     [type = "parsec_matrix_sym_block_cyclic_t*" hidden=on default="(parsec_matrix_sym_block_cyclic_t*)descA" aligned=ddescA]
+
+/**************************************************
+ *                       WARMUP                   *
+ **************************************************/
+WARMUP(m, n)
+
+// Execution space
+m = 0 .. descA->mt-1
+n = 0 .. descA->nt-1
+
+// Parallel partitioning
+: descA(m, n)
+
+// Parameters
+RW   A <- (descA->dtype & parsec_matrix_sym_block_cyclic_type && descAs->uplo == PARSEC_MATRIX_UPPER && m <= n)? ddescA(m, n)
+       <- (descA->dtype & parsec_matrix_sym_block_cyclic_type && descAs->uplo == PARSEC_MATRIX_LOWER && m >= n)? ddescA(m, n)
+       <- (descA->dtype == parsec_matrix_block_cyclic_type)? ddescA(m, n)
+       -> ddescA(m, n)
+
+BODY [type=CUDA]
+{
+    //printf("CUDA M=%d N=%d A=%p\n", m, n, A);
+    /* do nothing */
+}
+END
+
+BODY [type=HIP]
+{
+    //printf("HIP  M=%d N=%d A=%p\n", m, n, A);
+    /* do nothing */
+}
+END
+

--- a/src/zwarmup_wrapper.c
+++ b/src/zwarmup_wrapper.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2022      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * $COPYRIGHT
+ *
+ * @precisions normal z -> s d c
+ *
+ */
+
+#include "dplasma.h"
+#include "dplasma/types.h"
+#include "dplasma/types_lapack.h"
+#include "dplasmaaux.h"
+#include "parsec/utils/zone_malloc.h"
+
+#include "cores/dplasma_plasmatypes.h"
+#include <parsec/data_dist/matrix/sym_two_dim_rectangle_cyclic.h>
+#include "zwarmup.h"
+
+#define MAX_SHAPES 1
+
+/**
+ *******************************************************************************
+ *
+ * @ingroup dplasma_complex64
+ *
+ * dplasma_zwarmup_New - Generates the taskpool that loads all data to GPU once
+ *
+ * WARNING: The computations are not done by this call.
+ *
+ *******************************************************************************
+ *
+ * @param[in,out] A
+ *          Descriptor of the distributed matrix A.
+ *          On exit A is unmodified.
+ *
+ *******************************************************************************
+ *
+ * @return
+ *          \retval NULL if incorrect parameters are given.
+ *          \retval The parsec taskpool describing the operation that can be
+ *          enqueued in the runtime with parsec_context_add_taskpool(). It, then, needs to be
+ *          destroy with dplasma_zwarmup_Destruct();
+ *
+ *******************************************************************************
+ *
+ * @sa dplasma_zwarmup
+ * @sa dplasma_zwarmup_Destruct
+ *r @sa dplasma_cwarmup_New
+ * @sa dplasma_dwarmup_New
+ * @sa dplasma_swarmup_New
+ *
+ ******************************************************************************/
+parsec_taskpool_t*
+dplasma_zwarmup_New(parsec_tiled_matrix_t *A)
+{
+    parsec_taskpool_t *tp = NULL;
+    dplasma_data_collection_t * ddc_A = dplasma_wrap_data_collection(A);
+
+    int shape = 0;
+    dplasma_setup_adtt_all_loc( ddc_A,
+                                parsec_datatype_double_complex_t,
+                                PARSEC_MATRIX_FULL/*uplo*/, 1/*diag:for PARSEC_MATRIX_UPPER or PARSEC_MATRIX_LOWER types*/,
+                                &shape);
+
+    tp = (parsec_taskpool_t*)parsec_zwarmup_new( ddc_A );
+    assert(shape == MAX_SHAPES);
+    return tp;
+}
+
+/**
+ *******************************************************************************
+ *
+ * @ingroup dplasma_complex64
+ *
+ *  dplasma_zwarmup_Destruct - Free the data structure associated to an taskpool
+ *  created with dplasma_zwarmup_New().
+ *
+ *******************************************************************************
+ *
+ * @param[in,out] taskpool
+ *          On entry, the taskpool to destroy.
+ *          On exit, the taskpool cannot be used anymore.
+ *
+ *******************************************************************************
+ *
+ * @sa dplasma_zwarmup_New
+ * @sa dplasma_zwarmup
+ *
+ ******************************************************************************/
+void
+dplasma_zwarmup_Destruct( parsec_taskpool_t *tp )
+{
+    parsec_zwarmup_taskpool_t *parsec_zwarmup = (parsec_zwarmup_taskpool_t *)tp;
+    dplasma_clean_adtt_all_loc(parsec_zwarmup->_g_ddescA, MAX_SHAPES);
+    dplasma_data_collection_t * ddc_A = parsec_zwarmup->_g_ddescA;
+
+    parsec_taskpool_free(tp);
+    /* free the dplasma_data_collection_t */
+    dplasma_unwrap_data_collection(ddc_A);
+}
+
+/**
+ *******************************************************************************
+ *
+ * @ingroup dplasma_complex64
+ *
+ *******************************************************************************
+ *
+ * @param[in,out] parsec
+ *          The parsec context of the application that will run the operation.
+ *
+ * @param[in] A
+ *          Descriptor of the distributed matrix A.
+ *
+ *******************************************************************************
+ *
+ * @return
+ *          \retval -i if the ith parameters is incorrect.
+ *          \retval 0 on success.
+ *
+ *******************************************************************************
+ *
+ * @sa dplasma_zwarmup_New
+ * @sa dplasma_zwarmup_Destruct
+ * @sa dplasma_cwarmup
+ * @sa dplasma_dwarmup
+ * @sa dplasma_swarmup
+ *
+ ******************************************************************************/
+int
+dplasma_zwarmup( parsec_context_t *parsec,
+                parsec_tiled_matrix_t *A )
+{
+    parsec_taskpool_t *parsec_zwarmup = NULL;
+
+    parsec_zwarmup = dplasma_zwarmup_New( A );
+
+    if ( parsec_zwarmup != NULL ) {
+        parsec_context_add_taskpool( parsec, (parsec_taskpool_t*)parsec_zwarmup);
+        dplasma_wait_until_completion(parsec);
+        dplasma_zwarmup_Destruct( parsec_zwarmup );
+    }
+
+    return DPLASMA_SUCCESS;
+}
+

--- a/tools/PrecisionGenerator/subs.py
+++ b/tools/PrecisionGenerator/subs.py
@@ -164,6 +164,7 @@ subs = {
     ('slaset','dlaset','claset','zlaset'),
     ('slatms', 'dlatms', 'clatms', 'zlatms'),
     ('sprint','dprint','cprint','zprint'),
+    ('swarmup','dwarmup','cwarmup','zwarmup'),
     ('slacgv','dlacgv','clacgv','zlacgv'),
     ('slacpy','dlacpy','clacpy','zlacpy'),
     ('slagsy','dlagsy','claghe','zlaghe'),


### PR DESCRIPTION
This is an alternative mockup for pr #48.

In this PR, we have two phases, first we run a quick JDF that loads and spread a matrix on the GPUs, second we run a sub matrix PO to exercise the CuBLAS kernels. This happens all before the 'nruns'. 

We should discuss this, decide if we prefer this approach or #48, or a merger of the two. 


