### PR TITLE
modify dplasma so that passing naked N no longer works.

### DIFF
--- a/tests/common.c
+++ b/tests/common.c
@@ -283,8 +283,6 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
         c = getopt(argc, argv, GETOPT_STRING);
         (void) opt;
 #endif  /* defined(PARSEC_HAVE_GETOPT_LONG) */
-
-        // printf("%c: %s = %s\n", c, long_options[opt].name, optarg);
         switch(c)
         {
             case 'c': iparam[IPARAM_NCORES] = atoi(optarg); break;
@@ -436,12 +434,6 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
             *_argc = tmpc;
             *_argv = tmp;
         }
-    }
-    
-    /* Set matrices dimensions to default values if not provided */
-    /* Search for N as a bare number if not provided by -N */
-    if(0 == iparam[IPARAM_N] && optind < argc) {
-        iparam[IPARAM_N] = atoi(argv[optind++]);
     }
     (void)rc;
 }


### PR DESCRIPTION
As discussed in the Monday meeting, this small inconsistently led to some larger scale confusion trying to get results. Proposition to remove passing arguments to dplasma like:

`./tests/testing_dgemm 1000`

And forcing them to be in the form:

`./tests/testing_dgemm -N 1000`

(also removed someone's commented out debugging print statement)