### PR TITLE
update DPLASMA to newest version of PaRSEC

### DIFF
--- a/contrib/build_with_dplasma/testing_dpotrf_dtd_untied.c
+++ b/contrib/build_with_dplasma/testing_dpotrf_dtd_untied.c
@@ -412,7 +412,7 @@ int main(int argc, char **argv)
     }
 
     /* Finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( parsec, dtd_tp );
+    parsec_taskpool_wait( parsec, dtd_tp );
 
     /* Waiting on all handle and turning everything off for this context */
     parsec_context_wait(parsec);

--- a/tests/testing_zgemm_dtd.c
+++ b/tests/testing_zgemm_dtd.c
@@ -269,7 +269,7 @@ int main(int argc, char ** argv)
         parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcC );
 
         /* finishing all the tasks inserted, but not finishing the handle */
-        parsec_dtd_taskpool_wait( dtd_tp );
+        parsec_taskpool_wait( dtd_tp );
 
         /* Waiting on all handle and turning everything off for this context */
         parsec_context_wait( parsec );
@@ -514,7 +514,7 @@ int main(int argc, char ** argv)
                 parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcC );
 
                 /* finishing all the tasks inserted, but not finishing the handle */
-                parsec_dtd_taskpool_wait( dtd_tp );
+                parsec_taskpool_wait( dtd_tp );
 
                 /* Waiting on all handle and turning everything off for this context */
                 parsec_context_wait( parsec );

--- a/tests/testing_zgeqrf_dtd.c
+++ b/tests/testing_zgeqrf_dtd.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
     parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcT );
 
     /* finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
+    parsec_taskpool_wait( dtd_tp );
 
     /* Waiting on all handle and turning everything off for this context */
     parsec_context_wait( parsec );

--- a/tests/testing_zgeqrf_dtd_untied.c
+++ b/tests/testing_zgeqrf_dtd_untied.c
@@ -384,7 +384,7 @@ int main(int argc, char ** argv)
                        PARSEC_DTD_ARG_END );
 
     /* finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
+    parsec_taskpool_wait( dtd_tp );
 
     /* Waiting on all handle and turning everything off for this context */
     parsec_context_wait( parsec );

--- a/tests/testing_zgetrf_incpiv_dtd.c
+++ b/tests/testing_zgetrf_incpiv_dtd.c
@@ -377,7 +377,7 @@ int main(int argc, char ** argv)
     parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcIPIV );
 
     /* finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
+    parsec_taskpool_wait( dtd_tp );
 
     /* Waiting on all handle and turning everything off for this context */
     parsec_context_wait( parsec );

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -468,7 +468,7 @@ int main(int argc, char **argv)
     parsec_dtd_data_flush_all( dtd_tp, (parsec_data_collection_t *)&dcA );
 
     /* finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
+    parsec_taskpool_wait( dtd_tp );
 
     /* Waiting on all handle and turning everything off for this context */
     parsec_context_wait( parsec );

--- a/tests/testing_zpotrf_dtd_untied.c
+++ b/tests/testing_zpotrf_dtd_untied.c
@@ -409,7 +409,7 @@ int main(int argc, char **argv)
     }
 
     /* Finishing all the tasks inserted, but not finishing the handle */
-    parsec_dtd_taskpool_wait( dtd_tp );
+    parsec_taskpool_wait( dtd_tp );
 
     /* Waiting on all handle and turning everything off for this context */
     parsec_context_wait(parsec);


### PR DESCRIPTION
Currently, DPLASMA is a few months behind PaRSEC. Thanks to recent PR#411 on PaRSEC, DPLASMA is no longer compatible with the most recent version of PaRSEC - there needs to be some branching to get everything to work. This is a proposal to update DPLASMA such that both are compatible as of Jan 2023.