### PR TITLE
Do not cast MPI communicators to void*, this is incompatible with MPICH

### DIFF
--- a/src/scalapack_wrappers/dplasma_wrapper_pdgemm.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdgemm.c
@@ -280,7 +280,7 @@ void pdgemm_w( char* TRANSA, char* TRANSB,
     assert(comm_index_A == comm_index_B);
     assert(comm_index_A == comm_index_C);
 
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
 //    A: M x K
 //    B: K x N

--- a/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_1d.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_1d.c
@@ -196,7 +196,7 @@ void pdgetrf_w(int * M,
           DESCA[WRAPPER_M1_], DESCA[WRAPPER_N1_], DESCA[WRAPPER_MB1_], DESCA[WRAPPER_NB1_],
           DESCA[WRAPPER_RSRC1_], DESCA[WRAPPER_CSRC1_], DESCA[WRAPPER_LLD1_]);
 
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
     parsec_matrix_block_cyclic_t dcA_lapack;
     parsec_matrix_block_cyclic_lapack_init(&dcA_lapack, PARSEC_MATRIX_DOUBLE, PARSEC_MATRIX_LAPACK,

--- a/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_nopiv.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_nopiv.c
@@ -193,7 +193,7 @@ void pdgetrf_w(int * M,
           DESCA[WRAPPER_M1_], DESCA[WRAPPER_N1_], DESCA[WRAPPER_MB1_], DESCA[WRAPPER_NB1_],
           DESCA[WRAPPER_RSRC1_], DESCA[WRAPPER_CSRC1_], DESCA[WRAPPER_LLD1_]);
 
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
     parsec_matrix_block_cyclic_t dcA_lapack;
     parsec_matrix_block_cyclic_lapack_init(&dcA_lapack, PARSEC_MATRIX_DOUBLE, PARSEC_MATRIX_LAPACK,

--- a/src/scalapack_wrappers/dplasma_wrapper_pdlatsqr.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdlatsqr.c
@@ -260,7 +260,7 @@ void pdlatsqr_w(int * M,
         return;
     }
 
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
     parsec_matrix_block_cyclic_t dcA_lapack;
     parsec_matrix_block_cyclic_lapack_init(&dcA_lapack, PARSEC_MATRIX_DOUBLE, PARSEC_MATRIX_LAPACK,

--- a/src/scalapack_wrappers/dplasma_wrapper_pdpotrf.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdpotrf.c
@@ -170,7 +170,7 @@ void pdpotrf_w(char * UPLO,
           DESCA[WRAPPER_M1_], DESCA[WRAPPER_N1_], DESCA[WRAPPER_MB1_], DESCA[WRAPPER_NB1_],
           DESCA[WRAPPER_RSRC1_], DESCA[WRAPPER_CSRC1_], DESCA[WRAPPER_LLD1_]);
 
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
     dplasma_enum_t uplo_parsec = OP_UPLO(*UPLO);
 

--- a/src/scalapack_wrappers/dplasma_wrapper_pdtrmm.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdtrmm.c
@@ -262,7 +262,7 @@ void pdtrmm_w( char* SIDE, char* UPLO, char* TRANS, char* DIAG,
           *SIDE, *UPLO, *TRANS, *DIAG, mloc_B, nloc_B);
 
     assert(comm_index_A == comm_index_B);
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
     int Am, An, Bm, Bn;
 

--- a/src/scalapack_wrappers/dplasma_wrapper_pdtrsm.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdtrsm.c
@@ -252,7 +252,7 @@ void pdtrsm_w( char* SIDE, char* UPLO, char* TRANS, char* DIAG,
 
     assert(comm_index_A == comm_index_B);
 
-    parsec_init_wrapped_call((void*)comm_A);
+    parsec_init_wrapped_call(comm_A);
 
     int Am, An, Bm, Bn;
     if ( side == dplasmaLeft ) {


### PR DESCRIPTION
Make dplasma scalapack wrappers compile with MPICH