### PR TITLE
Bugfix/disable recursive

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -29,7 +29,7 @@ jobs:
       BUILD_DIRECTORY : "${{github.workspace}}/build/${{ matrix.build_type }}/shared_${{matrix.shared_type}}"
       INSTALL_DIRECTORY : "${{github.workspace}}/install/${{ matrix.build_type }}/shared_${{matrix.shared_type}}"
       RUNNER_ENV : github_runner
-      # Disable DPLASMA_WITH_RECURSIVE in CI tests until a real solution to https://github.com/ICLDisco/parsec/issues/548 is implemented
+      # Disable RECURSIVE in CI tests until a real solution to https://github.com/ICLDisco/parsec/issues/548 is implemented
       BUILD_CONFIG : >
         -G Ninja
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -37,7 +37,7 @@ jobs:
         -DMPIEXEC_PREFLAGS='--bind-to;none;--oversubscribe'
         -DCMAKE_INSTALL_PREFIX=$INSTALL_DIRECTORY
         -DDPLASMA_PRECISIONS=d
-        -DPLASMA_WITH_RECURSIVE=OFF
+        -DPARSEC_HAVE_DEV_RECURSIVE_SUPPORT=OFF
 
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,6 @@ option(BUILD_SHARED_LIBS
 option(DPLASMA_WITH_SCALAPACK_WRAPPER
   "Build a ScaLAPACK compatible API to DPLASMA" ON)
 
-option(DPLASMA_WITH_RECURSIVE
-  "Enable recursive kernels to be called when available" ON)
-
 option(DPLASMA_TRACE_KERNELS
   "Enable tracing dplasma kernel calls for debugging (slow)" OFF)
 

--- a/src/include/dplasma/config.h.in
+++ b/src/include/dplasma/config.h.in
@@ -2,12 +2,10 @@
 #define DPLASMA_CONFIG_H_HAS_BEEN_INCLUDED
 
 /* Optional features */
-#cmakedefine DPLASMA_WITH_RECURSIVE
 #cmakedefine DPLASMA_TRACE_KERNELS
 
 /* GPU Backends */
 #cmakedefine DPLASMA_HAVE_CUDA
-#cmakedefine DPLASMA_GPU_WITH_MAGMA
 
 /* system feature tests */
 #cmakedefine DPLASMA_HAVE_COMPLEX_H

--- a/src/zgeqrf.jdf
+++ b/src/zgeqrf.jdf
@@ -13,10 +13,8 @@ extern "C" %{
 #include "dplasmajdf.h"
 #include "parsec/data_dist/matrix/matrix.h"
 
-#if defined(DPLASMA_WITH_RECURSIVE)
 #include "parsec/data_dist/matrix/subtile.h"
 #include "parsec/recursive.h"
-#endif
 
 #if defined(DPLASMA_HAVE_CUDA)
 #include "cores/dplasma_zcores.h"

--- a/src/zpotrf_L.jdf
+++ b/src/zpotrf_L.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2022 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
@@ -12,15 +12,13 @@ extern "C" %{
 #include "dplasmajdf.h"
 #include "parsec/data_dist/matrix/matrix.h"
 
-#if defined(DPLASMA_WITH_RECURSIVE)
 #include "parsec/data_dist/matrix/subtile.h"
 #include "parsec/recursive.h"
-#endif
+static void zpotrf_L_update_INFO(parsec_taskpool_t* _tp, const parsec_recursive_callback_t* data);
 
 #if defined(DPLASMA_HAVE_CUDA)
 #include <cublas_v2.h>
 #include "potrf_cublas_utils.h"
-
 #endif  /* defined(DPLASMA_HAVE_CUDA) */
 
 /* Define the different shapes this JDF is using */
@@ -50,10 +48,6 @@ extern "C" %{
  * tasks and that information is lost) the approach is to force a reshapping.
  *
  */
-
-#if defined(DPLASMA_WITH_RECURSIVE)
-static void zpotrf_L_update_INFO(parsec_taskpool_t* _tp, const parsec_recursive_callback_t* data);
-#endif  /* defined(DPLASMA_WITH_RECURSIVE) */
 
 /*
  * Priorities used in this jdf:
@@ -530,7 +524,6 @@ END
 
 extern "C" %{
 
-#if defined(DPLASMA_WITH_RECURSIVE)
 /*
  * A function to recursively update the value of the INFO argument for
  * recursive calls. We need a special function because the recursive calls being asynchronous
@@ -553,7 +546,6 @@ static void zpotrf_L_update_INFO(parsec_taskpool_t* _tp, const parsec_recursive_
     }
     dplasma_zpotrf_Destruct(_tp);
 }
-#endif  /* defined(DPLASMA_WITH_RECURSIVE) */
 
 %}
 

--- a/src/zpotrf_U.jdf
+++ b/src/zpotrf_U.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2022 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
@@ -11,15 +11,13 @@ extern "C" %{
 #include "dplasmajdf.h"
 #include "parsec/data_dist/matrix/matrix.h"
 
-#if defined(DPLASMA_WITH_RECURSIVE)
 #include "parsec/data_dist/matrix/subtile.h"
 #include "parsec/recursive.h"
-#endif
+static void zpotrf_U_update_INFO(parsec_taskpool_t* _tp, const parsec_recursive_callback_t* data);
 
 #if defined(DPLASMA_HAVE_CUDA)
 #include <cublas_v2.h>
 #include "potrf_cublas_utils.h"
-
 #endif  /* defined(DPLASMA_HAVE_CUDA) */
 
 /* Define the different shapes this JDF is using */
@@ -49,10 +47,6 @@ extern "C" %{
  * tasks and that information is lost) the approach is to force a reshapping.
  *
  */
-
-#if defined(DPLASMA_WITH_RECURSIVE)
-static void zpotrf_U_update_INFO(parsec_taskpool_t* _tp, const parsec_recursive_callback_t* data);
-#endif  /* defined(DPLASMA_WITH_RECURSIVE) */
 
 /*
  * Priorities used in this jdf:
@@ -544,7 +538,6 @@ END
 
 extern "C" %{
 
-#if defined(DPLASMA_WITH_RECURSIVE)
 /*
  * A function to recursively update the value of the INFO argument for
  * recursive calls. We need a special function because the recursive calls being asynchronous
@@ -567,7 +560,6 @@ static void zpotrf_U_update_INFO(parsec_taskpool_t* _tp, const parsec_recursive_
     }
     dplasma_zpotrf_Destruct(_tp);
 }
-#endif  /* defined(DPLASMA_WITH_RECURSIVE) */
 
 %}
 


### PR DESCRIPTION
1. disable recursive in CI (using PARSEC control)
2. remove ineffective  option DPLASMA_WITH_RECURSIVE, it cannot be disabled (can't ifdef 
away the BODY [RECURSIVE]) so it serves no purpose.


