### PR TITLE
Add control dependencies in SYRK

### DIFF
--- a/src/zsyrk_LN.jdf
+++ b/src/zsyrk_LN.jdf
@@ -21,6 +21,9 @@ descA     [type = "const parsec_tiled_matrix_t*"]
 beta      [type = "dplasma_complex64_t"]
 descC     [type = "parsec_tiled_matrix_t*"]
 
+/* Look ahead on both dimensions */
+lookX  [type = "int" hidden=on default="dplasma_aux_getGEMMLookahead(descC)"]
+
 
 zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_NB(descA, k)); %} ]
   /* Execution Space */
@@ -35,6 +38,8 @@ zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_N
              <- ((0==k)) ? descC(n,n)
              -> ((descA->nt>=(k+2))) ? C zsyrk(n, k+1)
              -> ((descA->nt==(k+1))) ? descC(n,n)
+
+  CTL ctlx -> (k < (descA->nt-lookX)) ? ctlx zsyrk_in_data_A0(n, k+lookX)
 
 BODY
 {
@@ -64,6 +69,7 @@ zsyrk_in_data_A0(n, k) [profile = off]
 
   READ  A    <- descA(n,k)
              -> A zsyrk(n, k)
+  CTL ctlx   <- (k >= lookX) ? ctlx zsyrk(n, k-lookX)
 
 BODY
 {
@@ -86,6 +92,9 @@ zgemm(n, m, k) [ flops = inline_c %{ return FLOPS_ZGEMM(CLEAN_MB(descC, m), CLEA
              <- ((k>=1)) ? C zgemm(n, m, k-1)
              -> ((descA->nt==(k+1))) ? descC(m,n)
              -> ((descA->nt>=(k+2))) ? C zgemm(n, m, k+1)
+
+  CTL ctla -> (k < (descA->nt-lookX)) ? ctla zgemm_in_data_A0(m, k+lookX)
+  CTL ctlb -> (k < (descA->nt-lookX)) ? ctlb zgemm_in_data_A1(n, k+lookX)
 
 BODY
   {
@@ -118,6 +127,7 @@ zgemm_in_data_A1(n, k) [profile = off]
 
   READ  B    <- descA(n,k)
              -> B zgemm(n, (n+1)..(descC->mt-1), k)
+  CTL ctlb   <- (k >= lookX) ? ctlb zgemm(n, (n+1) .. (descC->mt-1), k-lookX)
 
 BODY
 {
@@ -135,6 +145,7 @@ zgemm_in_data_A0(m, k) [profile = off]
 
   READ  A    <- descA(m,k)
              -> A zgemm(0..(descC->mt-2), m, k)
+  CTL ctla   <- (k >= lookX) ? ctla zgemm(0 .. (m-1), m, k-lookX)
 
 BODY
 {

--- a/src/zsyrk_LT.jdf
+++ b/src/zsyrk_LT.jdf
@@ -21,6 +21,9 @@ descA     [type = "const parsec_tiled_matrix_t*"]
 beta      [type = "dplasma_complex64_t"]
 descC     [type = "parsec_tiled_matrix_t*"]
 
+/* Look ahead on both dimensions */
+lookX  [type = "int" hidden=on default="dplasma_aux_getGEMMLookahead(descC)"]
+
 
 zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_MB(descA, k)); %} ]
   /* Execution Space */
@@ -35,6 +38,8 @@ zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_M
              <- ((k>=1)) ? C zsyrk(n, k-1)
              -> ((descA->mt>=(2+k))) ? C zsyrk(n, k+1)
              -> ((descA->mt==(1+k))) ? descC(n,n)
+
+  CTL ctlx -> (k < (descA->nt-lookX)) ? ctlx zsyrk_in_data_A0(n, k+lookX)
 
 BODY
 {
@@ -64,6 +69,7 @@ zsyrk_in_data_A0(n, k) [profile = off]
 
   READ  A    <- descA(k,n)
              -> A zsyrk(n, k)
+  CTL ctlx   <- (k >= lookX) ? ctlx zsyrk(n, k-lookX)
 
 BODY
 {
@@ -86,6 +92,9 @@ zgemm(n, m, k) [ flops = inline_c %{ return FLOPS_ZGEMM(CLEAN_MB(descC, m), CLEA
              <- ((0==k)) ? descC(m,n)
              -> ((descA->mt==(k+1))) ? descC(m,n)
              -> ((descA->mt>=(2+k))) ? C zgemm(n, m, k+1)
+
+  CTL ctla -> (k < (descA->nt-lookX)) ? ctla zgemm_in_data_A0(m, k+lookX)
+  CTL ctlb -> (k < (descA->nt-lookX)) ? ctlb zgemm_in_data_A1(n, k+lookX)
 
 BODY
 {
@@ -117,6 +126,7 @@ zgemm_in_data_A1(n, k) [profile = off]
 
   READ  B    <- descA(k,n)
              -> B zgemm(n, (n+1)..(descC->mt-1), k)
+  CTL ctlb   <- (k >= lookX) ? ctlb zgemm(n, (n+1) .. (descC->mt-1), k-lookX)
 
 BODY
 {
@@ -134,6 +144,7 @@ zgemm_in_data_A0(m, k) [profile = off]
 
   READ  A    <- descA(k,m)
              -> A zgemm(0..(descC->mt-2), m, k)
+  CTL ctla   <- (k >= lookX) ? ctla zgemm(0 .. (m-1), m, k-lookX)
 
 BODY
 {

--- a/src/zsyrk_UN.jdf
+++ b/src/zsyrk_UN.jdf
@@ -21,6 +21,9 @@ descA     [type = "const parsec_tiled_matrix_t*"]
 beta      [type = "dplasma_complex64_t"]
 descC     [type = "parsec_tiled_matrix_t*"]
 
+/* Look ahead on both dimensions */
+lookX  [type = "int" hidden=on default="dplasma_aux_getGEMMLookahead(descC)"]
+
 
 zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_NB(descA, k)); %} ]
   /* Execution Space */
@@ -35,6 +38,8 @@ zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_N
              <- ((k>=1)) ? C zsyrk(n, k-1)
              -> ((descA->nt>=(2+k))) ? C zsyrk(n, k+1)
              -> ((descA->nt==(k+1))) ? descC(n,n)
+
+  CTL ctlx -> (k < (descA->nt-lookX)) ? ctlx zsyrk_in_data_A0(n, k+lookX)
 
 BODY
 {
@@ -63,6 +68,7 @@ zsyrk_in_data_A0(n, k) [profile = off]
 
   READ  A    <- descA(n,k)
              -> A zsyrk(n, k)
+  CTL ctlx   <- (k >= lookX) ? ctlx zsyrk(n, k-lookX)
 
 BODY
 {
@@ -85,6 +91,9 @@ zgemm(n, m, k) [ flops = inline_c %{ return FLOPS_ZGEMM(CLEAN_NB(descC, n), CLEA
              <- ((k>=1)) ? C zgemm(n, m, k-1)
              -> ((descA->nt>=(k+2))) ? C zgemm(n, m, k+1)
              -> ((descA->nt==(k+1))) ? descC(n,m)
+
+  CTL ctla -> (k < (descA->nt-lookX)) ? ctla zgemm_in_data_A1(m, k+lookX)
+  CTL ctlb -> (k < (descA->nt-lookX)) ? ctlb zgemm_in_data_A0(n, k+lookX)
 
 BODY
 {
@@ -117,6 +126,7 @@ zgemm_in_data_A1(m, k) [profile = off]
 
   READ  B    <- descA(m,k)
              -> B zgemm(0..(descC->mt-2), m, k)
+  CTL ctla   <- (k >= lookX) ? ctla zgemm(0 .. (m-1), m, k-lookX)
 
 BODY
 {
@@ -134,6 +144,7 @@ zgemm_in_data_A0(n, k) [profile = off]
 
   READ  A    <- descA(n,k)
              -> A zgemm(n, (n+1)..(descC->mt-1), k)
+  CTL ctlb   <- (k >= lookX) ? ctlb zgemm(n, (n+1) .. (descC->mt-1), k-lookX)
 
 BODY
 {

--- a/src/zsyrk_UT.jdf
+++ b/src/zsyrk_UT.jdf
@@ -21,6 +21,9 @@ descA     [type = "const parsec_tiled_matrix_t*"]
 beta      [type = "dplasma_complex64_t"]
 descC     [type = "parsec_tiled_matrix_t*"]
 
+/* Look ahead on both dimensions */
+lookX  [type = "int" hidden=on default="dplasma_aux_getGEMMLookahead(descC)"]
+
 
 zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_MB(descA, k)); %} ]
   /* Execution Space */
@@ -35,6 +38,8 @@ zsyrk(n, k) [ flops = inline_c %{ return FLOPS_ZSYRK(CLEAN_NB(descC, n), CLEAN_M
              <- (k >= 1) ? C zsyrk(n, k-1)
              -> ((descA->mt-1) >  k) ? C zsyrk(n, k+1)
              -> ((descA->mt-1) == k) ? descC(n,n)
+
+  CTL ctlx -> (k < (descA->nt-lookX)) ? ctlx zsyrk_in_data_A0(n, k+lookX)
 
 BODY
 {
@@ -63,6 +68,7 @@ zsyrk_in_data_A0(n, k) [profile = off]
 
   READ  A    <- descA(k,n)
              -> A zsyrk(n, k)
+  CTL ctlx   <- (k >= lookX) ? ctlx zsyrk(n, k-lookX)
 
 BODY
 {
@@ -85,6 +91,9 @@ zgemm(n, m, k) [ flops = inline_c %{ return FLOPS_ZGEMM(CLEAN_NB(descC, n), CLEA
              <- ((0==k)) ? descC(n,m)
              -> ((descA->mt==(k+1))) ? descC(n,m)
              -> ((descA->mt>=(2+k))) ? C zgemm(n, m, k+1)
+
+  CTL ctla -> (k < (descA->nt-lookX)) ? ctla zgemm_in_data_A1(m, k+lookX)
+  CTL ctlb -> (k < (descA->nt-lookX)) ? ctlb zgemm_in_data_A0(n, k+lookX)
 
 BODY
 {
@@ -115,6 +124,7 @@ zgemm_in_data_A1(m, k) [profile = off]
 
   READ  B    <- descA(k,m)
              -> B zgemm(0..(descC->mt-2), m, k)
+  CTL ctla   <- (k >= lookX) ? ctla zgemm(0 .. (m-1), m, k-lookX)
 
 BODY
 {
@@ -132,6 +142,7 @@ zgemm_in_data_A0(n, k) [profile = off]
 
   READ  A    <- descA(k,n)
              -> A zgemm(n, (n+1)..(descC->mt-1), k)
+  CTL ctlb   <- (k >= lookX) ? ctlb zgemm(n, (n+1) .. (descC->mt-1), k-lookX)
 
 BODY
 {


### PR DESCRIPTION
Add control dependencies in SYRK to limited parallelism and therefore, memory usage.