### PR TITLE
Consistent ordering of RECURSIVE/CUDA bodies: CUDA first, recursive

### DIFF
--- a/src/zpotrf_L.jdf
+++ b/src/zpotrf_L.jdf
@@ -113,32 +113,6 @@ RW T <- (k == 0) ? ddescA(k, k)            [ type        = %{ return ADTT_READ(d
 
 ; (k >= (descA->mt - PRI_CHANGE)) ? (descA->mt - k) * (descA->mt - k) * (descA->mt - k) : PRI_MAX
 
-BODY [type=RECURSIVE]
-{
-    int tempkm = k == descA->mt-1 ? descA->m - k*descA->mb : descA->mb;
-
-    if (tempkm > smallnb)
-    {
-        subtile_desc_t *small_descT;
-        parsec_taskpool_t *parsec_zpotrf;
-
-        small_descT = subtile_desc_create( descA, k, k,
-                                           smallnb, smallnb, 0, 0, tempkm, tempkm );
-        small_descT->mat = T;
-
-        parsec_zpotrf = dplasma_zpotrf_New(uplo, (parsec_tiled_matrix_t *)small_descT, (int*)&info );
-
-        parsec_recursivecall((parsec_task_t*)this_task,
-                             parsec_zpotrf, zpotrf_recursive_cb,
-                             1, small_descT);
-
-        return PARSEC_HOOK_RETURN_ASYNC;
-    }
-    /* Go for the sequential CPU version */
-    return PARSEC_HOOK_RETURN_NEXT;
-}
-END
-
 BODY [type=CUDA
       weigth=k]
 {
@@ -167,6 +141,32 @@ BODY [type=CUDA
 
     status = cusolverDnZpotrf( handles->cusolverDn_handle, cublas_uplo, tempkm, T, ldak, workspace, wp->lwork, d_iinfo);
     PARSEC_CUDA_CHECK_ERROR( "cublasZpotrf_v2 ", status, {return PARSEC_HOOK_RETURN_ERROR;} );
+}
+END
+
+BODY [type=RECURSIVE]
+{
+    int tempkm = k == descA->mt-1 ? descA->m - k*descA->mb : descA->mb;
+
+    if (tempkm > smallnb)
+    {
+        subtile_desc_t *small_descT;
+        parsec_taskpool_t *parsec_zpotrf;
+
+        small_descT = subtile_desc_create( descA, k, k,
+                                           smallnb, smallnb, 0, 0, tempkm, tempkm );
+        small_descT->mat = T;
+
+        parsec_zpotrf = dplasma_zpotrf_New(uplo, (parsec_tiled_matrix_t *)small_descT, (int*)&info );
+
+        parsec_recursivecall((parsec_task_t*)this_task,
+                             parsec_zpotrf, zpotrf_recursive_cb,
+                             1, small_descT);
+
+        return PARSEC_HOOK_RETURN_ASYNC;
+    }
+    /* Go for the sequential CPU version */
+    return PARSEC_HOOK_RETURN_NEXT;
 }
 END
 

--- a/src/zpotrf_U.jdf
+++ b/src/zpotrf_U.jdf
@@ -112,32 +112,6 @@ RW T <- (k == 0) ? ddescA(k, k)            [ type        = %{ return ADTT_READ(d
 
 ; (k >= (descA->nt - PRI_CHANGE)) ? (descA->nt - k) * (descA->nt - k) * (descA->nt - k) : PRI_MAX
 
-BODY [type=RECURSIVE]
-{
-    int tempkn = k == descA->nt-1 ? descA->n - k*descA->nb : descA->nb;
-
-    if (tempkn > smallnb)
-    {
-        subtile_desc_t *small_descT;
-        parsec_taskpool_t *parsec_zpotrf;
-
-        small_descT = subtile_desc_create( descA, k, k,
-                                           smallnb, smallnb, 0, 0, tempkn, tempkn );
-        small_descT->mat = T;
-
-        parsec_zpotrf = dplasma_zpotrf_New(uplo, (parsec_tiled_matrix_t *)small_descT, (int*)&info );
-
-        parsec_recursivecall((parsec_task_t*)this_task,
-                             parsec_zpotrf, zpotrf_recursive_cb,
-                             1, small_descT);
-
-        return PARSEC_HOOK_RETURN_ASYNC;
-    }
-    /* Go for the sequential CPU version */
-    return PARSEC_HOOK_RETURN_NEXT;
-}
-END
-
 BODY [type=CUDA
       weigth=k]
 {
@@ -166,6 +140,32 @@ BODY [type=CUDA
 
     status = cusolverDnZpotrf( handles->cusolverDn_handle, cublas_uplo, tempkn, T, ldak, workspace, wp->lwork, d_iinfo);
     PARSEC_CUDA_CHECK_ERROR( "cublasZpotrf_v2 ", status, {return PARSEC_HOOK_RETURN_ERROR;} );
+}
+END
+
+BODY [type=RECURSIVE]
+{
+    int tempkn = k == descA->nt-1 ? descA->n - k*descA->nb : descA->nb;
+
+    if (tempkn > smallnb)
+    {
+        subtile_desc_t *small_descT;
+        parsec_taskpool_t *parsec_zpotrf;
+
+        small_descT = subtile_desc_create( descA, k, k,
+                                           smallnb, smallnb, 0, 0, tempkn, tempkn );
+        small_descT->mat = T;
+
+        parsec_zpotrf = dplasma_zpotrf_New(uplo, (parsec_tiled_matrix_t *)small_descT, (int*)&info );
+
+        parsec_recursivecall((parsec_task_t*)this_task,
+                             parsec_zpotrf, zpotrf_recursive_cb,
+                             1, small_descT);
+
+        return PARSEC_HOOK_RETURN_ASYNC;
+    }
+    /* Go for the sequential CPU version */
+    return PARSEC_HOOK_RETURN_NEXT;
 }
 END
 


### PR DESCRIPTION
Consistent ordering of RECURSIVE/CUDA bodies: CUDA first, recursive second.

This ordering is consistent with existing ordering in zgeqrf, and most kernels in zpotrf (except for po_po); this will prefer using GPU kernels if available, and fallback to recursive if load balancer lets a kernel fallback to CPU. 