### PR TITLE
bugifx: dtd would do del2arena after releasing the corresponding adt,

### DIFF
--- a/tests/testing_zgemm_dtd.c
+++ b/tests/testing_zgemm_dtd.c
@@ -267,8 +267,8 @@ int main(int argc, char ** argv)
         parsec_taskpool_free( dtd_tp );
 
         /* Cleaning data arrays we allocated for communication */
-        parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
         dplasma_matrix_del2arena( tile_full );
+        parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
         parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
 
         parsec_data_free(dcA.mat);
@@ -519,8 +519,8 @@ int main(int argc, char ** argv)
                 parsec_taskpool_free( dtd_tp );
 
                 /* Cleaning data arrays we allocated for communication */
-                parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
                 dplasma_matrix_del2arena( tile_full );
+                parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
                 parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
 
                 parsec_data_free(dcA.mat);

--- a/tests/testing_zgeqrf_dtd.c
+++ b/tests/testing_zgeqrf_dtd.c
@@ -398,10 +398,10 @@ int main(int argc, char **argv)
     }
 
     /* Cleaning data arrays we allocated for communication */
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_rectangle );
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
 
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcT );

--- a/tests/testing_zgeqrf_dtd_untied.c
+++ b/tests/testing_zgeqrf_dtd_untied.c
@@ -447,14 +447,14 @@ int main(int argc, char ** argv)
     }
 
     /* Cleaning data arrays we allocated for communication */
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_LOWER);
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_lower );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_UPPER);
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_LOWER);
     dplasma_matrix_del2arena( tile_upper );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_UPPER);
     dplasma_matrix_del2arena( tile_rectangle );
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
 
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcT );

--- a/tests/testing_zgetrf_incpiv_dtd.c
+++ b/tests/testing_zgetrf_incpiv_dtd.c
@@ -447,12 +447,12 @@ int main(int argc, char ** argv)
     }
 
     /* Cleaning data arrays we allocated for communication */
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_rectangle );
-    parsec_dtd_destroy_arena_datatype(parsec, L_TILE_RECTANGLE);
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
     dplasma_matrix_del2arena( l_tile_rectangle );
+    parsec_dtd_destroy_arena_datatype(parsec, L_TILE_RECTANGLE);
 
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcL );

--- a/tests/testing_zpotrf_dtd_untied.c
+++ b/tests/testing_zpotrf_dtd_untied.c
@@ -476,8 +476,8 @@ int main(int argc, char **argv)
         parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcX );
     }
 
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_full );
+    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_data_free(dcA.mat); dcA.mat = NULL;
     parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);


### PR DESCRIPTION
bugifx: dtd would do del2arena after releasing the corresponding adt, which would randomly crash.

as seen in CI build #181 https://github.com/ICLDisco/dplasma/actions/runs/6631295204/job/18014509921