### PR TITLE
cleanup: some weight properties were leftover

### DIFF
--- a/src/zpotrf_L.jdf
+++ b/src/zpotrf_L.jdf
@@ -115,8 +115,7 @@ RW T <- (k == 0) ? ddescA(k, k)            [ type        = %{ return ADTT_READ(d
 
 ; (k >= (descA->mt - PRI_CHANGE)) ? (descA->mt - k) * (descA->mt - k) * (descA->mt - k) : PRI_MAX
 
-BODY [type=CUDA
-      weigth=k]
+BODY [type=CUDA]
 {
     int tempkm = k == descA->mt-1 ? descA->m - k*descA->mb : descA->mb;
     int ldak = LDA(ddescA, T);

--- a/src/zpotrf_U.jdf
+++ b/src/zpotrf_U.jdf
@@ -114,8 +114,7 @@ RW T <- (k == 0) ? ddescA(k, k)            [ type        = %{ return ADTT_READ(d
 
 ; (k >= (descA->nt - PRI_CHANGE)) ? (descA->nt - k) * (descA->nt - k) * (descA->nt - k) : PRI_MAX
 
-BODY [type=CUDA
-      weigth=k]
+BODY [type=CUDA]
 {
     int tempkn = k == descA->nt-1 ? descA->n - k*descA->nb : descA->nb;
     int ldak = LDA(ddescA, T);


### PR DESCRIPTION
cleanup: some weight properties were leftover
because they had a typo "weigth" and were not found by search-replace