### PR TITLE
When recursive is disabled, first gpu is at index 1

### DIFF
--- a/tests/testing_zgemm.c
+++ b/tests/testing_zgemm.c
@@ -335,7 +335,8 @@ static void warmup_zgemm(int rank, int nodes, int random_seed, parsec_context_t 
 
     /* Now do the other devices, skipping RECURSIVE */
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         for(int i = 0; i < MT; i++) {
             for(int j = 0; j < NT; j++) {
                 if( rank == (int)dcC.super.super.rank_of(&dcC.super.super, i, j) ) {

--- a/tests/testing_zgemm_dtd.c
+++ b/tests/testing_zgemm_dtd.c
@@ -696,7 +696,8 @@ static void warmup_zgemm(int rank, int nodes, int random_seed, parsec_context_t 
 
     /* Now do the other devices, skipping RECURSIVE */
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         for(int i = 0; i < MT; i++) {
             for(int j = 0; j < NT; j++) {
                 if( rank == (int)dcC.super.super.rank_of(&dcC.super.super, i, j) ) {

--- a/tests/testing_zgeqrf.c
+++ b/tests/testing_zgeqrf.c
@@ -413,7 +413,8 @@ static void warmup_zgeqrf(int rank, int random_seed, parsec_context_t *parsec)
     dplasma_zgeqrf_Destruct(zgeqrf);
 
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         for(int i = 0; i < MT; i++) {
             for(int j = 0; j < NT; j++) {
                 parsec_data_t *dta = dcA.super.super.data_of(&dcA.super.super, i, j);

--- a/tests/testing_zgeqrf_dtd.c
+++ b/tests/testing_zgeqrf_dtd.c
@@ -644,7 +644,8 @@ static void warmup_zgeqrf(int rank, int random_seed, parsec_context_t *parsec)
     dplasma_zgeqrf_Destruct(zgeqrf);
 
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         for(int i = 0; i < MT; i++) {
             for(int j = 0; j < NT; j++) {
                 parsec_data_t *dta = dcA.super.super.data_of(&dcA.super.super, i, j);

--- a/tests/testing_zgeqrf_dtd_untied.c
+++ b/tests/testing_zgeqrf_dtd_untied.c
@@ -697,7 +697,8 @@ static void warmup_zgeqrf(int rank, int random_seed, parsec_context_t *parsec)
     dplasma_zgeqrf_Destruct(zgeqrf);
 
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         for(int i = 0; i < MT; i++) {
             for(int j = 0; j < NT; j++) {
                 parsec_data_t *dta = dcA.super.super.data_of(&dcA.super.super, i, j);

--- a/tests/testing_zpoinv.c
+++ b/tests/testing_zpoinv.c
@@ -143,7 +143,8 @@ static void warmup_zpoinv(int rank, dplasma_enum_t uplo, int random_seed, parsec
 
     /* Now do the other devices, skipping RECURSIVE */
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         if(PARSEC_MATRIX_LOWER == uplo) {
             for(int i = 0; i < MT; i++) {
                 for(int j = 0; j <= i; j++) {

--- a/tests/testing_zpotrf.c
+++ b/tests/testing_zpotrf.c
@@ -175,7 +175,8 @@ static void warmup_zpotrf(int rank, dplasma_enum_t uplo, int random_seed, parsec
 
     /* Now do the other devices, skipping RECURSIVE */
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         if(PARSEC_MATRIX_LOWER == uplo) {
             for(int i = 0; i < MT; i++) {
                 for(int j = 0; j <= i; j++) {

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -427,7 +427,8 @@ static void warmup_zpotrf(int rank, dplasma_enum_t uplo, int random_seed, parsec
 
     /* Now do the other devices, skipping RECURSIVE */
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         if(PARSEC_MATRIX_LOWER == uplo) {
             for(int i = 0; i < MT; i++) {
                 for(int j = 0; j <= i; j++) {

--- a/tests/testing_zpotrf_dtd_untied.c
+++ b/tests/testing_zpotrf_dtd_untied.c
@@ -526,7 +526,8 @@ static void warmup_zpotrf(int rank, dplasma_enum_t uplo, int random_seed, parsec
 
     /* Now do the other devices, skipping RECURSIVE */
     /* We know that there is a GPU-enabled version of this operation, so warm it up if some device is enabled */
-    for(did = 2; did < (int)parsec_nb_devices; did++) {
+    for(did = 1; did < (int)parsec_nb_devices; did++) {
+        if(!parsec_mca_device_is_gpu(did)) continue;
         if(PARSEC_MATRIX_LOWER == uplo) {
             for(int i = 0; i < MT; i++) {
                 for(int j = 0; j <= i; j++) {


### PR DESCRIPTION
We would skip the warmup of device 1 in some cases. 