### PR TITLE
update: use the new parsec dtd api

### DIFF
--- a/src/utils/dplasma_arena_datatype.c
+++ b/src/utils/dplasma_arena_datatype.c
@@ -239,8 +239,10 @@ int dplasma_cleanup_datatype( parsec_datatype_t *dtt )
 #ifdef REUSE_ARENA_DATATYPE
     /* The key of a datatype can only be constructed with the arguments used during creation.
      * Thus, datatypes will be cleaned during callback during parsec context at fini.
+     * Set the pointer to PARSEC_DATATYPE_NULL (so that adt_destruct doesn't complain) but
+     * the actual datatype shall remain as it is still referenced from the hashtable.
      */
-    (void)dtt;
+    *dtt = PARSEC_DATATYPE_NULL;
     return 0;
 #else
     return parsec_type_free( dtt );

--- a/tests/testing_zgemm_dtd.c
+++ b/tests/testing_zgemm_dtd.c
@@ -93,11 +93,13 @@ int main(int argc, char ** argv)
         parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 
         /* Default type */
-        parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+
+        parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
         dplasma_add2arena_tile( tile_full,
                                 dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                                 PARSEC_ARENA_ALIGNMENT_SSE,
                                 parsec_datatype_double_complex_t, dcA.super.mb );
+        parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
         /* matrix generation */
         if(loud > 2) printf("+++ Generate matrices ... ");
@@ -261,7 +263,7 @@ int main(int argc, char ** argv)
 
         /* Cleaning data arrays we allocated for communication */
         dplasma_matrix_del2arena( tile_full );
-        parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+        parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
         parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
 
         parsec_data_free(dcA.mat);
@@ -321,11 +323,12 @@ int main(int argc, char ** argv)
 
                 /* Allocating data arrays to be used by comm engine */
                 /* Default type */
-                parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+                parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
                 dplasma_add2arena_tile( tile_full,
                                         dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                                         PARSEC_ARENA_ALIGNMENT_SSE,
                                         parsec_datatype_double_complex_t, dcA.super.mb );
+                parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
@@ -505,7 +508,7 @@ int main(int argc, char ** argv)
 
                 /* Cleaning data arrays we allocated for communication */
                 dplasma_matrix_del2arena( tile_full );
-                parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+                parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
                 parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
 
                 parsec_data_free(dcA.mat);

--- a/tests/testing_zgeqrf_dtd.c
+++ b/tests/testing_zgeqrf_dtd.c
@@ -218,17 +218,19 @@ int main(int argc, char **argv)
 
     /* Allocating data arrays to be used by comm engine */
     /* Default type */
-    parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+    parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_tile( tile_full,
                             dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                             PARSEC_ARENA_ALIGNMENT_SSE,
                             parsec_datatype_double_complex_t, dcA.super.mb );
+    parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
-    parsec_arena_datatype_t *tile_rectangle = parsec_dtd_create_arena_datatype(parsec, &TILE_RECTANGLE);
+    parsec_arena_datatype_t *tile_rectangle = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_rectangle( tile_rectangle,
                                  dcT.super.mb*dcT.super.nb*sizeof(dplasma_complex64_t),
                                  PARSEC_ARENA_ALIGNMENT_SSE,
                                  parsec_datatype_double_complex_t, dcT.super.mb, dcT.super.nb, -1);
+    parsec_dtd_attach_arena_datatype(parsec, tile_rectangle, &TILE_RECTANGLE);
 
     /* Registering the handle with parsec context */
     parsec_context_add_taskpool(parsec, dtd_tp);
@@ -399,9 +401,9 @@ int main(int argc, char **argv)
 
     /* Cleaning data arrays we allocated for communication */
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+    parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_rectangle );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
+    parsec_dtd_free_arena_datatype(parsec, TILE_RECTANGLE);
 
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcT );

--- a/tests/testing_zgeqrf_dtd_untied.c
+++ b/tests/testing_zgeqrf_dtd_untied.c
@@ -341,31 +341,35 @@ int main(int argc, char ** argv)
 
     /* Allocating data arrays to be used by comm engine */
     /* Default type */
-    parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+    parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_tile( tile_full,
                             dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                             PARSEC_ARENA_ALIGNMENT_SSE,
                             parsec_datatype_double_complex_t, dcA.super.mb );
+    parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
     /* Lower triangular part of tile without diagonal */
-    parsec_arena_datatype_t *tile_lower = parsec_dtd_create_arena_datatype(parsec, &TILE_LOWER);
+    parsec_arena_datatype_t *tile_lower = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_lower( tile_lower,
                              dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                              PARSEC_ARENA_ALIGNMENT_SSE,
                              parsec_datatype_double_complex_t, dcA.super.mb, 0 );
+    parsec_dtd_attach_arena_datatype(parsec, tile_lower, &TILE_LOWER);
 
     /* Upper triangular part of tile with diagonal */
-    parsec_arena_datatype_t *tile_upper = parsec_dtd_create_arena_datatype(parsec, &TILE_UPPER);
+    parsec_arena_datatype_t *tile_upper = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_upper( tile_upper,
                              dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                              PARSEC_ARENA_ALIGNMENT_SSE,
                              parsec_datatype_double_complex_t, dcA.super.mb, 1 );
+    parsec_dtd_attach_arena_datatype(parsec, tile_upper, &TILE_UPPER);
 
-    parsec_arena_datatype_t *tile_rectangle = parsec_dtd_create_arena_datatype(parsec, &TILE_RECTANGLE);
+    parsec_arena_datatype_t *tile_rectangle = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_rectangle( tile_rectangle,
                                  dcT.super.mb*dcT.super.nb*sizeof(dplasma_complex64_t),
                                  PARSEC_ARENA_ALIGNMENT_SSE,
                                  parsec_datatype_double_complex_t, dcT.super.mb, dcT.super.nb, -1);
+    parsec_dtd_attach_arena_datatype(parsec, tile_rectangle, &TILE_RECTANGLE);
 
     /* Registering the handle with parsec context */
     parsec_context_add_taskpool(parsec, dtd_tp);
@@ -448,13 +452,13 @@ int main(int argc, char ** argv)
 
     /* Cleaning data arrays we allocated for communication */
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+    parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_lower );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_LOWER);
+    parsec_dtd_free_arena_datatype(parsec, TILE_LOWER);
     dplasma_matrix_del2arena( tile_upper );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_UPPER);
+    parsec_dtd_free_arena_datatype(parsec, TILE_UPPER);
     dplasma_matrix_del2arena( tile_rectangle );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
+    parsec_dtd_free_arena_datatype(parsec, TILE_RECTANGLE);
 
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcT );

--- a/tests/testing_zgetrf_incpiv_dtd.c
+++ b/tests/testing_zgetrf_incpiv_dtd.c
@@ -245,25 +245,28 @@ int main(int argc, char ** argv)
 
     /* Allocating data arrays to be used by comm engine */
     /* A */
-    parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+    parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_tile( tile_full,
                             dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                             PARSEC_ARENA_ALIGNMENT_SSE,
                             parsec_datatype_double_complex_t, dcA.super.mb );
+    parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
     /* IPIV */
-    parsec_arena_datatype_t *tile_rectangle = parsec_dtd_create_arena_datatype(parsec, &TILE_RECTANGLE);
+    parsec_arena_datatype_t *tile_rectangle = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_rectangle( tile_rectangle,
                                  dcA.super.mb*sizeof(int),
                                  PARSEC_ARENA_ALIGNMENT_SSE,
                                  parsec_datatype_int_t, dcA.super.mb, 1, -1 );
+    parsec_dtd_attach_arena_datatype(parsec, tile_rectangle, &TILE_RECTANGLE);
 
     /* L */
-    parsec_arena_datatype_t *l_tile_rectangle = parsec_dtd_create_arena_datatype(parsec, &L_TILE_RECTANGLE);
+    parsec_arena_datatype_t *l_tile_rectangle = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_rectangle( l_tile_rectangle,
                                  dcL.super.mb*dcL.super.nb*sizeof(dplasma_complex64_t),
                                  PARSEC_ARENA_ALIGNMENT_SSE,
                                  parsec_datatype_double_complex_t, dcL.super.mb, dcL.super.nb, -1);
+    parsec_dtd_attach_arena_datatype(parsec, l_tile_rectangle, &L_TILE_RECTANGLE);
 
     /* Registering the handle with parsec context */
     parsec_context_add_taskpool( parsec, dtd_tp );
@@ -448,11 +451,11 @@ int main(int argc, char ** argv)
 
     /* Cleaning data arrays we allocated for communication */
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+    parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
     dplasma_matrix_del2arena( tile_rectangle );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_RECTANGLE);
+    parsec_dtd_free_arena_datatype(parsec, TILE_RECTANGLE);
     dplasma_matrix_del2arena( l_tile_rectangle );
-    parsec_dtd_destroy_arena_datatype(parsec, L_TILE_RECTANGLE);
+    parsec_dtd_free_arena_datatype(parsec, L_TILE_RECTANGLE);
 
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcL );

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -74,11 +74,12 @@ int main(int argc, char **argv)
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new();
 
     /* Allocating data arrays to be used by comm engine */
-    parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+    parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_tile( tile_full,
                             dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                             PARSEC_ARENA_ALIGNMENT_SSE,
                             parsec_datatype_double_complex_t, dcA.super.mb );
+    parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
     /* Registering the handle with parsec context */
     parsec_context_add_taskpool( parsec, dtd_tp );
@@ -377,7 +378,7 @@ int main(int argc, char **argv)
 
     /* Cleaning data arrays we allocated for communication */
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+    parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
 
     parsec_data_free(dcA.mat); dcA.mat = NULL;

--- a/tests/testing_zpotrf_dtd_untied.c
+++ b/tests/testing_zpotrf_dtd_untied.c
@@ -371,11 +371,12 @@ int main(int argc, char **argv)
     parsec_taskpool_t *dtd_tp = parsec_dtd_taskpool_new( );
 
     /* Default type */
-    parsec_arena_datatype_t *tile_full = parsec_dtd_create_arena_datatype(parsec, &TILE_FULL);
+    parsec_arena_datatype_t *tile_full = PARSEC_OBJ_NEW(parsec_arena_datatype_t);
     dplasma_add2arena_tile( tile_full,
                             dcA.super.mb*dcA.super.nb*sizeof(dplasma_complex64_t),
                             PARSEC_ARENA_ALIGNMENT_SSE,
                             parsec_datatype_double_complex_t, dcA.super.mb );
+    parsec_dtd_attach_arena_datatype(parsec, tile_full, &TILE_FULL);
 
     /* Registering the handle with parsec context */
     parsec_context_add_taskpool( parsec, dtd_tp );
@@ -477,7 +478,7 @@ int main(int argc, char **argv)
     }
 
     dplasma_matrix_del2arena( tile_full );
-    parsec_dtd_destroy_arena_datatype(parsec, TILE_FULL);
+    parsec_dtd_free_arena_datatype(parsec, TILE_FULL);
     parsec_dtd_data_collection_fini( (parsec_data_collection_t *)&dcA );
     parsec_data_free(dcA.mat); dcA.mat = NULL;
     parsec_tiled_matrix_destroy( (parsec_tiled_matrix_t*)&dcA);


### PR DESCRIPTION
 update: use the new parsec dtd api to allocate initialize and free arena_datatypes in a consistent order 

required after icldisco/parsec#623

* [ ] update parsec submodule pointer after pr merged in parsec