### PR TITLE
Cleanup/copycheck

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,18 +1,28 @@
-Yu Pei
-Reazul Hoque
-Chongxiao Cao
-David Eberius
-Wei Wu
-Stephen Richmond
+AUTHORS (in order of first contribution)
+========================================
+
+George Bosilca
 Thomas Herault
 Aurelien Bouteiller
-Anthony Danalis
-George Bosilca
 Mathieu Faverge
-Stephanie Moreaud
+Narapat Saengpatsa
+Pierre Lemarinier
+Anthony Danalis
+Hatem Ltaief
 Peter Gaultney
+Stephanie Moreaud
+Guillaume Aupy
+Omar Zenati
+Julien Herrmann
+Wei Wu
+Reazul Hoque
+Chongxiao Cao
 Damien Genet
-Amina Guermouche
+Aaron Welch
 Nuria Losada
+Yu Pei
+Joseph Schuchart
+Omri Mor
+Brieuc Nicolas
 
 and many others.

--- a/cmake_modules/DplasmaCompilerFlags.cmake
+++ b/cmake_modules/DplasmaCompilerFlags.cmake
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2009-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
+
 include (CheckCCompilerFlag)
 include (CheckFortranCompilerFlag)
 

--- a/cmake_modules/FindLAPACKE.cmake
+++ b/cmake_modules/FindLAPACKE.cmake
@@ -45,7 +45,7 @@
 #
 
 # ==============================================================================
-# Copyright (c) 2019-2023 The University of Tennessee and The University
+# Copyright (c) 2019-2024 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 #

--- a/cmake_modules/ParseArguments.cmake
+++ b/cmake_modules/ParseArguments.cmake
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2011-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 macro(PARSE_ARGUMENTS prefix arg_names option_names)
   set(DEFAULT_ARGS)
   foreach(arg_name ${arg_names})

--- a/cmake_modules/dplasma-config.cmake.in
+++ b/cmake_modules/dplasma-config.cmake.in
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2020-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 set(DPLASMA_VERSION @DPLASMA_VERSION_MAJOR@.@DPLASMA_VERSION_MINOR@.@DPLASMA_VERSION_PATCH@)
 
 @PACKAGE_INIT@

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018-2023 The University of Tennessee and The University
+# Copyright (c) 2018-2024 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
 

--- a/contrib/build_with_dplasma/common_timing.h
+++ b/contrib/build_with_dplasma/common_timing.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2009-2019 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #ifndef TIMING_H
 #define TIMING_H
 

--- a/contrib/build_with_dplasma/testing_dpotrf_dtd_untied.c
+++ b/contrib/build_with_dplasma/testing_dpotrf_dtd_untied.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 The University of Tennessee and The University
+ * Copyright (c) 2015-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/contrib/spack/packages/dplasma/package.py
+++ b/contrib/spack/packages/dplasma/package.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2019-2022  The University of Tennessee and the University
+# Copyright (c) 2019-2023 The University of Tennessee and the University
 #                          of Tennessee Research Foundation.  All rights
 #                          reserved.
 #

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,9 @@
 #
-#Use Doxygen to create the API documentation
+# Copyright (c) 2019-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
 #
+# Use Doxygen to create the API documentation
 
 option(BUILD_DOCUMENTATION "Generate API documentation during the build process." OFF)
 

--- a/examples/dqr_driver.c
+++ b/examples/dqr_driver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 The University of Tennessee and The University
+ * Copyright (c) 2016-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2009-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 include_directories(BEFORE "${CMAKE_CURRENT_BINARY_DIR}")
 include_directories(BEFORE "${CMAKE_CURRENT_BINARY_DIR}/include")
 if(NOT DPLASMA_BUILD_INPLACE)

--- a/src/butterfly_map.c
+++ b/src/butterfly_map.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 The University of Tennessee and The University
+ * Copyright (c) 2012-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * $COPYRIGHT

--- a/src/butterfly_map.c
+++ b/src/butterfly_map.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2012-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/butterfly_map.h
+++ b/src/butterfly_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2015 The University of Tennessee and The University
+ * Copyright (c) 2012-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * $COPYRIGHT

--- a/src/butterfly_map.h
+++ b/src/butterfly_map.h
@@ -2,7 +2,6 @@
  * Copyright (c) 2012-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/cores/CMakeLists.txt
+++ b/src/cores/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2011-2022 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 set(ZHEADERS
   dplasma_zcores.h core_zblas.h
 )

--- a/src/cores/core_dsblas.h
+++ b/src/cores/core_dsblas.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019      The University of Tennessee and The University
+ * Copyright (c) 2019-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Imported from:

--- a/src/cores/core_zhebut.c
+++ b/src/cores/core_zhebut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 The University of Tennessee and The University
+ * Copyright (c) 2011-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/cores/dplasma_zcores.h
+++ b/src/cores/dplasma_zcores.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2019 The University of Tennessee and The University
+ * Copyright (c) 2011-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/cores/global.c
+++ b/src/cores/global.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019      The University of Tennessee and The University
+ * Copyright (c) 2019-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Imported from:

--- a/src/cuda/lapack_cuda_stage_in.c
+++ b/src/cuda/lapack_cuda_stage_in.c
@@ -3,8 +3,6 @@
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  *
- * $COPYRIGHT
- *
  */
 
 #include "dplasma.h"

--- a/src/dplasma_hqr.c
+++ b/src/dplasma_hqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/dplasma_hqr_dbg.c
+++ b/src/dplasma_hqr_dbg.c
@@ -3,8 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
- * $COPYRIGHT
- *
  * @precisions normal z -> s d c
  *
  *

--- a/src/dplasma_systolic_qr.c
+++ b/src/dplasma_systolic_qr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/dplasma_zcheck.c
+++ b/src/dplasma_zcheck.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/dplasma_zcheck.c
+++ b/src/dplasma_zcheck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/dplasmaaux.c
+++ b/src/dplasmaaux.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/dplasmaaux.h
+++ b/src/dplasmaaux.h
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/dplasmaaux_cuda.c
+++ b/src/dplasmaaux_cuda.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2023-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/dplasmaaux_cuda.h
+++ b/src/dplasmaaux_cuda.h
@@ -2,7 +2,6 @@
  * Copyright (c) 2023-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/dplasmaaux_hip.c
+++ b/src/dplasmaaux_hip.c
@@ -2,7 +2,6 @@
  * Copyright (c) 2023-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/dplasmaaux_hip.h
+++ b/src/dplasmaaux_hip.h
@@ -2,7 +2,6 @@
  * Copyright (c) 2023-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/dplasmajdf.h
+++ b/src/dplasmajdf.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2020-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
 #ifndef _DPLASMAJDF_H_
 #define _DPLASMAJDF_H_
 

--- a/src/dplasmajdf_lapack_dtt.h
+++ b/src/dplasmajdf_lapack_dtt.h
@@ -3,8 +3,6 @@
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  *
- * $COPYRIGHT
- *
  */
 #ifndef INCLUDE_DPLASMA_LAPACK_DTT_H
 #define INCLUDE_DPLASMA_LAPACK_DTT_H

--- a/src/dtd_wrappers/CMakeLists.txt
+++ b/src/dtd_wrappers/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2023      The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 include(PrecisionGenerator)
 
 set(DTD_HEADERS

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2009-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 include(PrecisionGenerator)
 
 # reset variables

--- a/src/include/dplasma.h.in
+++ b/src/include/dplasma.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/include/dplasma/constants.h
+++ b/src/include/dplasma/constants.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020      The University of Tennessee and The University
+ * Copyright (c) 2020-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/include/dplasma/dplasma_z.h
+++ b/src/include/dplasma/dplasma_z.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/include/dplasma/qr_param.h
+++ b/src/include/dplasma/qr_param.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/include/dplasma/types.h
+++ b/src/include/dplasma/types.h
@@ -2,7 +2,7 @@
 #define DPLASMA_DATATYPE_H_HAS_BEEN_INCLUDED
 
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/src/include/dplasma/types_lapack.h
+++ b/src/include/dplasma/types_lapack.h
@@ -2,7 +2,7 @@
 #define DPLASMA_LAPACK_DATATYPE_H_HAS_BEEN_INCLUDED
 
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/src/map2.jdf
+++ b/src/map2.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/map2_wrapper.c
+++ b/src/map2_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/map2_wrapper.c
+++ b/src/map2_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/map_wrapper.c
+++ b/src/map_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  */
 

--- a/src/map_wrapper.c
+++ b/src/map_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/potrf_gpu_workspaces.h
+++ b/src/potrf_gpu_workspaces.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 The University of Tennessee and The University
+ * Copyright (c) 2020-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/scalapack_wrappers/CMakeLists.txt
+++ b/src/scalapack_wrappers/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2021-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 # Generate ScaLAPACK wrappers provided by DPLASMA
 if(NOT DPLASMA_WITH_SCALAPACK_WRAPPER)
   return() # told to not build them

--- a/src/scalapack_wrappers/common.c
+++ b/src/scalapack_wrappers/common.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
 parsec_context_t* parsec_ctx = NULL;

--- a/src/scalapack_wrappers/common.h
+++ b/src/scalapack_wrappers/common.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #ifndef SCALAPACK_WRAPPER
 #define SCALAPACK_WRAPPER
 

--- a/src/scalapack_wrappers/dplasma_wrapper_parsec_init.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_parsec_init.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
 

--- a/src/scalapack_wrappers/dplasma_wrapper_pdgemm.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdgemm.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
 /*

--- a/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_1d.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_1d.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
   /************************************************************************
     DPLASMA GETRF_1D doesn't support 2D block cyclic.

--- a/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_nopiv.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdgetrf_nopiv.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
   /************************************************************************

--- a/src/scalapack_wrappers/dplasma_wrapper_pdlatsqr.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdlatsqr.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
   /************************************************************************
     LAPACK 3.7.0 introduces the LATSQR routine implementing the

--- a/src/scalapack_wrappers/dplasma_wrapper_pdpotrf.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdpotrf.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
 /*      SUBROUTINE PDPOTRF( UPLO, N, A, IA, JA, DESCA, INFO )

--- a/src/scalapack_wrappers/dplasma_wrapper_pdtrmm.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdtrmm.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
  /*

--- a/src/scalapack_wrappers/dplasma_wrapper_pdtrsm.c
+++ b/src/scalapack_wrappers/dplasma_wrapper_pdtrsm.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "common.h"
 
 /*

--- a/src/utils/dplasma_arena_datatype.c
+++ b/src/utils/dplasma_arena_datatype.c
@@ -3,8 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
- * $COPYRIGHT
- *
  */
 #include "dplasma_arena_datatype.h"
 #include <string.h>

--- a/src/utils/dplasma_arena_datatype.h
+++ b/src/utils/dplasma_arena_datatype.h
@@ -2,7 +2,7 @@
 #define DPLASMA_ARENA_DATATYPE_H_HAS_BEEN_INCLUDED
 
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/src/utils/dplasma_info.c
+++ b/src/utils/dplasma_info.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include <string.h>
 #include <stdio.h>
 #include "utils/dplasma_info.h"

--- a/src/utils/dplasma_info.h
+++ b/src/utils/dplasma_info.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #ifndef _DPLASMA_INFO_H
 #define _DPLASMA_INFO_H
 

--- a/src/utils/dplasma_lapack_adtt.c
+++ b/src/utils/dplasma_lapack_adtt.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021-2023 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "dplasma_lapack_adtt.h"
 #include <string.h>
 

--- a/src/utils/dplasma_lapack_adtt.h
+++ b/src/utils/dplasma_lapack_adtt.h
@@ -2,7 +2,7 @@
 #define DPLASMA_LAPACK_ADT_H_HAS_BEEN_INCLUDED
 
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/src/zgeadd_wrapper.c
+++ b/src/zgeadd_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgebmm.jdf
+++ b/src/zgebmm.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgebrd_ge2gb.jdf
+++ b/src/zgebrd_ge2gb.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgebrd_ge2gb.jdf
+++ b/src/zgebrd_ge2gb.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgebrd_ge2gb_wrapper.c
+++ b/src/zgebrd_ge2gb_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgebut.jdf
+++ b/src/zgebut.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgelqf.jdf
+++ b/src/zgelqf.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgelqf.jdf
+++ b/src/zgelqf.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgelqf_param.jdf
+++ b/src/zgelqf_param.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgelqf_param.jdf
+++ b/src/zgelqf_param.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgelqf_param_wrapper.c
+++ b/src/zgelqf_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgelqf_wrapper.c
+++ b/src/zgelqf_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgelqf_wrapper.c
+++ b/src/zgelqf_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgelqs_param_wrapper.c
+++ b/src/zgelqs_param_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgelqs_param_wrapper.c
+++ b/src/zgelqs_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgelqs_wrapper.c
+++ b/src/zgelqs_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgelqs_wrapper.c
+++ b/src/zgelqs_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgels_wrapper.c
+++ b/src/zgels_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgels_wrapper.c
+++ b/src/zgels_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgemm_NN.jdf
+++ b/src/zgemm_NN.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_NN_gpu.jdf
+++ b/src/zgemm_NN_gpu.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 

--- a/src/zgemm_NN_summa.jdf
+++ b/src/zgemm_NN_summa.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_NT.jdf
+++ b/src/zgemm_NT.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_NT_summa.jdf
+++ b/src/zgemm_NT_summa.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_TN.jdf
+++ b/src/zgemm_TN.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_TN_summa.jdf
+++ b/src/zgemm_TN_summa.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_TT.jdf
+++ b/src/zgemm_TT.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_TT_summa.jdf
+++ b/src/zgemm_TT_summa.jdf
@@ -5,7 +5,6 @@ extern "C" %{
  *                         reserved.
  *
  * @precisions normal z -> s d c
- * $COPYRIGHT
  *
  */
 #include "dplasma/config.h"

--- a/src/zgemm_wrapper.c
+++ b/src/zgemm_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrf.jdf
+++ b/src/zgeqrf.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrf.jdf
+++ b/src/zgeqrf.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2023 The University of Tennessee and The University
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrf_param.jdf
+++ b/src/zgeqrf_param.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrf_param.jdf
+++ b/src/zgeqrf_param.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrf_param_wrapper.c
+++ b/src/zgeqrf_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgeqrf_wrapper.c
+++ b/src/zgeqrf_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrf_wrapper.c
+++ b/src/zgeqrf_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrfr_geqrt.jdf
+++ b/src/zgeqrfr_geqrt.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrfr_geqrt.jdf
+++ b/src/zgeqrfr_geqrt.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2021 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrfr_tsmqr.jdf
+++ b/src/zgeqrfr_tsmqr.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrfr_tsmqr.jdf
+++ b/src/zgeqrfr_tsmqr.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrfr_tsqrt.jdf
+++ b/src/zgeqrfr_tsqrt.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrfr_tsqrt.jdf
+++ b/src/zgeqrfr_tsqrt.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrfr_unmqr.jdf
+++ b/src/zgeqrfr_unmqr.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrfr_unmqr.jdf
+++ b/src/zgeqrfr_unmqr.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrs_param_wrapper.c
+++ b/src/zgeqrs_param_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrs_param_wrapper.c
+++ b/src/zgeqrs_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgeqrs_wrapper.c
+++ b/src/zgeqrs_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgeqrs_wrapper.c
+++ b/src/zgeqrs_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zger.jdf
+++ b/src/zger.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/zger_wrapper.c
+++ b/src/zger_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgesv_1d_wrapper.c
+++ b/src/zgesv_1d_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgesv_incpiv_wrapper.c
+++ b/src/zgesv_incpiv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgetrf_1d.jdf
+++ b/src/zgetrf_1d.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrf_1d.jdf
+++ b/src/zgetrf_1d.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgetrf_1d_wrapper.c
+++ b/src/zgetrf_1d_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgetrf_1d_wrapper.c
+++ b/src/zgetrf_1d_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrf_incpiv.jdf
+++ b/src/zgetrf_incpiv.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrf_incpiv.jdf
+++ b/src/zgetrf_incpiv.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgetrf_incpiv_wrapper.c
+++ b/src/zgetrf_incpiv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgetrf_incpiv_wrapper.c
+++ b/src/zgetrf_incpiv_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrf_nopiv.jdf
+++ b/src/zgetrf_nopiv.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrf_nopiv_wrapper.c
+++ b/src/zgetrf_nopiv_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrf_nopiv_wrapper.c
+++ b/src/zgetrf_nopiv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgetrf_ptgpanel.jdf
+++ b/src/zgetrf_ptgpanel.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2018 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2010-2017 Bordeaux INP, CNRS (LaBRI UMR 5800), Inria,

--- a/src/zgetrf_ptgpanel_wrapper.c
+++ b/src/zgetrf_ptgpanel_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgetrf_qrf.jdf
+++ b/src/zgetrf_qrf.jdf
@@ -5,8 +5,6 @@ extern "C" %{
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
  *
- * $COPYRIGHT
- *
  * @precisions normal z -> s d c
  *
  */

--- a/src/zgetrf_qrf_wrapper.c
+++ b/src/zgetrf_qrf_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zgetrf_qrf_wrapper.c
+++ b/src/zgetrf_qrf_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zgetrs_incpiv_wrapper.c
+++ b/src/zgetrs_incpiv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zgetrs_wrapper.c
+++ b/src/zgetrs_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zhbrdt.jdf
+++ b/src/zhbrdt.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zhbrdt.jdf
+++ b/src/zhbrdt.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zhebut.jdf
+++ b/src/zhebut.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zheev_wrapper.c
+++ b/src/zheev_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zheev_wrapper.c
+++ b/src/zheev_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zhemm.jdf
+++ b/src/zhemm.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> c
  *

--- a/src/zhemm_wrapper.c
+++ b/src/zhemm_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zhemm_wrapper.c
+++ b/src/zhemm_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> c
  *

--- a/src/zher2k_LC.jdf
+++ b/src/zher2k_LC.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zher2k_LN.jdf
+++ b/src/zher2k_LN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zher2k_UC.jdf
+++ b/src/zher2k_UC.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zher2k_UN.jdf
+++ b/src/zher2k_UN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zher2k_wrapper.c
+++ b/src/zher2k_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> z c
  *

--- a/src/zher2k_wrapper.c
+++ b/src/zher2k_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zherbt_L.jdf
+++ b/src/zherbt_L.jdf
@@ -1,10 +1,9 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zherbt_U.jdf
+++ b/src/zherbt_U.jdf
@@ -1,10 +1,9 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation. All rights
+ *                         reserved.
+ * Copyright (c) 2013      Inria. All rights reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/zherbt_wrapper.c
+++ b/src/zherbt_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zherk_LC.jdf
+++ b/src/zherk_LC.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zherk_LN.jdf
+++ b/src/zherk_LN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zherk_UC.jdf
+++ b/src/zherk_UC.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zherk_UN.jdf
+++ b/src/zherk_UN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c
  *

--- a/src/zherk_wrapper.c
+++ b/src/zherk_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zhetrd_b2s.jdf
+++ b/src/zhetrd_b2s.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zhetrd_b2s.jdf
+++ b/src/zhetrd_b2s.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zhetrd_h2b_L.jdf
+++ b/src/zhetrd_h2b_L.jdf
@@ -1,10 +1,9 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zhetrd_h2b_U.jdf
+++ b/src/zhetrd_h2b_U.jdf
@@ -1,10 +1,9 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation. All rights
+ *                         reserved.
+ * Copyright (c) 2013      Inria. All rights reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/zhetrd_wrapper.c
+++ b/src/zhetrd_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020 The University of Tennessee and The University
+ * Copyright (c) 2014-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zhetrf.jdf
+++ b/src/zhetrf.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zhetrf.jdf
+++ b/src/zhetrf.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zhetrf_wrapper.c
+++ b/src/zhetrf_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zhetrs_wrapper.c
+++ b/src/zhetrs_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zlacpy_wrapper.c
+++ b/src/zlacpy_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlange_frb_cyclic.jdf
+++ b/src/zlange_frb_cyclic.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlange_one_cyclic.jdf
+++ b/src/zlange_one_cyclic.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlange_wrapper.c
+++ b/src/zlange_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlanhe_wrapper.c
+++ b/src/zlanhe_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlanm2.jdf
+++ b/src/zlanm2.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- *  Copyright (c) 2011-2020 The University of Tennessee and The University
+ *  Copyright (c) 2011-2022 The University of Tennessee and The University
  *                          of Tennessee Research Foundation.  All rights
  *                          reserved.
  *  Copyright (c) 2013-2016 Inria. All rights reserved.

--- a/src/zlanm2_wrapper.c
+++ b/src/zlanm2_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlansy.jdf
+++ b/src/zlansy.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- *  Copyright (c) 2011-2020 The University of Tennessee and The University
+ *  Copyright (c) 2011-2022 The University of Tennessee and The University
  *                          of Tennessee Research Foundation.  All rights
  *                          reserved.
  *  Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlansy_wrapper.c
+++ b/src/zlansy_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlantr_wrapper.c
+++ b/src/zlantr_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlascal_wrapper.c
+++ b/src/zlascal_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlaset_wrapper.c
+++ b/src/zlaset_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlaswp.jdf
+++ b/src/zlaswp.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2013 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlaswp_wrapper.c
+++ b/src/zlaswp_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlatms_wrapper.c
+++ b/src/zlatms_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zlauum_L.jdf
+++ b/src/zlauum_L.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2014 Inria. All rights reserved.

--- a/src/zlauum_L.jdf
+++ b/src/zlauum_L.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2014 Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zlauum_U.jdf
+++ b/src/zlauum_U.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2014 Inria. All rights reserved.

--- a/src/zlauum_U.jdf
+++ b/src/zlauum_U.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2014 Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zlauum_wrapper.c
+++ b/src/zlauum_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zplghe_wrapper.c
+++ b/src/zplghe_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zplgsy_wrapper.c
+++ b/src/zplgsy_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zplrnt_wrapper.c
+++ b/src/zplrnt_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpltmg_chebvand.jdf
+++ b/src/zpltmg_chebvand.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2011-2013 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpltmg_fiedler.jdf
+++ b/src/zpltmg_fiedler.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2011-2013 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpltmg_hankel.jdf
+++ b/src/zpltmg_hankel.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpltmg_toeppd.jdf
+++ b/src/zpltmg_toeppd.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpltmg_wrapper.c
+++ b/src/zpltmg_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpoinv_L.jdf
+++ b/src/zpoinv_L.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zpoinv_U.jdf
+++ b/src/zpoinv_U.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zpoinv_wrapper.c
+++ b/src/zpoinv_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zpoinv_wrapper.c
+++ b/src/zpoinv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zposv_wrapper.c
+++ b/src/zposv_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zposv_wrapper.c
+++ b/src/zposv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpotrf_L.jdf
+++ b/src/zpotrf_L.jdf
@@ -5,8 +5,6 @@ extern "C" %{
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
  *
- * $COPYRIGHT
- *
  * @precisions normal z -> s d c
  *
  */

--- a/src/zpotrf_U.jdf
+++ b/src/zpotrf_U.jdf
@@ -5,8 +5,6 @@ extern "C" %{
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
  *
- * $COPYRIGHT
- *
  * @precisions normal z -> s d c
  *
  */

--- a/src/zpotrf_wrapper.c
+++ b/src/zpotrf_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zpotrf_wrapper.c
+++ b/src/zpotrf_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023 The University of Tennessee and The University
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpotri_wrapper.c
+++ b/src/zpotri_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zpotri_wrapper.c
+++ b/src/zpotri_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zpotrs_wrapper.c
+++ b/src/zpotrs_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zpotrs_wrapper.c
+++ b/src/zpotrs_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zprint.jdf
+++ b/src/zprint.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zprint_wrapper.c
+++ b/src/zprint_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zsymm.jdf
+++ b/src/zsymm.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ *  Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                          of Tennessee Research Foundation.  All rights
+ *                          reserved.
  *
  * @precisions normal z -> c d s
  *

--- a/src/zsymm_wrapper.c
+++ b/src/zsymm_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zsymm_wrapper.c
+++ b/src/zsymm_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> c d s
  *

--- a/src/zsyr2k_LN.jdf
+++ b/src/zsyr2k_LN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyr2k_LT.jdf
+++ b/src/zsyr2k_LT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyr2k_UN.jdf
+++ b/src/zsyr2k_UN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyr2k_UT.jdf
+++ b/src/zsyr2k_UT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyr2k_wrapper.c
+++ b/src/zsyr2k_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyr2k_wrapper.c
+++ b/src/zsyr2k_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zsyrk_LN.jdf
+++ b/src/zsyrk_LN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyrk_LT.jdf
+++ b/src/zsyrk_LT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyrk_UN.jdf
+++ b/src/zsyrk_UN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyrk_UT.jdf
+++ b/src/zsyrk_UT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2020
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> z c d s
  *

--- a/src/zsyrk_wrapper.c
+++ b/src/zsyrk_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/ztrdsm.jdf
+++ b/src/ztrdsm.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrdsm.jdf
+++ b/src/ztrdsm.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrdsm_wrapper.c
+++ b/src/ztrdsm_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/ztrmdm.jdf
+++ b/src/ztrmdm.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmdm.jdf
+++ b/src/ztrmdm.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_LLN.jdf
+++ b/src/ztrmm_LLN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_LLN.jdf
+++ b/src/ztrmm_LLN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_LLT.jdf
+++ b/src/ztrmm_LLT.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_LLT.jdf
+++ b/src/ztrmm_LLT.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_LUN.jdf
+++ b/src/ztrmm_LUN.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_LUN.jdf
+++ b/src/ztrmm_LUN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_LUT.jdf
+++ b/src/ztrmm_LUT.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_LUT.jdf
+++ b/src/ztrmm_LUT.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_RLN.jdf
+++ b/src/ztrmm_RLN.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_RLN.jdf
+++ b/src/ztrmm_RLN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_RLT.jdf
+++ b/src/ztrmm_RLT.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_RLT.jdf
+++ b/src/ztrmm_RLT.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_RUN.jdf
+++ b/src/ztrmm_RUN.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_RUN.jdf
+++ b/src/ztrmm_RUN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_RUT.jdf
+++ b/src/ztrmm_RUT.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrmm_RUT.jdf
+++ b/src/ztrmm_RUT.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrmm_wrapper.c
+++ b/src/ztrmm_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/ztrsm_LLN.jdf
+++ b/src/ztrsm_LLN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_LLT.jdf
+++ b/src/ztrsm_LLT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_LUN.jdf
+++ b/src/ztrsm_LUN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_LUT.jdf
+++ b/src/ztrsm_LUT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_RLN.jdf
+++ b/src/ztrsm_RLN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_RLT.jdf
+++ b/src/ztrsm_RLT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_RUN.jdf
+++ b/src/ztrsm_RUN.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_RUT.jdf
+++ b/src/ztrsm_RUT.jdf
@@ -1,10 +1,8 @@
 extern "C" %{
 /*
- *  Copyright (c) 2010-2024
- *
- *  The University of Tennessee and The University
- *  of Tennessee Research Foundation.  All rights
- *  reserved.
+ * Copyright (c) 2010-2024 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_wrapper.c
+++ b/src/ztrsm_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsm_wrapper.c
+++ b/src/ztrsm_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrsmpl_incpiv.jdf
+++ b/src/ztrsmpl_incpiv.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2013 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrsmpl_incpiv.jdf
+++ b/src/ztrsmpl_incpiv.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsmpl_incpiv_wrapper.c
+++ b/src/ztrsmpl_incpiv_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/ztrsmpl_ptgpanel.jdf
+++ b/src/ztrsmpl_ptgpanel.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2018 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2010-2017 Bordeaux INP, CNRS (LaBRI UMR 5800), Inria,

--- a/src/ztrsmpl_ptgpanel_wrapper.c
+++ b/src/ztrsmpl_ptgpanel_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/ztrsmpl_qrf.jdf
+++ b/src/ztrsmpl_qrf.jdf
@@ -4,7 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrsmpl_qrf.jdf
+++ b/src/ztrsmpl_qrf.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrsmpl_qrf_wrapper.c
+++ b/src/ztrsmpl_qrf_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/ztrtri_L.jdf
+++ b/src/ztrtri_L.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  * $COPYRIGHT
  *

--- a/src/ztrtri_L.jdf
+++ b/src/ztrtri_L.jdf
@@ -2,8 +2,6 @@ extern "C" %{
 /*
  * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrtri_U.jdf
+++ b/src/ztrtri_U.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/ztrtri_U.jdf
+++ b/src/ztrtri_U.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/ztrtri_wrapper.c
+++ b/src/ztrtri_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunglq.jdf
+++ b/src/zunglq.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.

--- a/src/zunglq.jdf
+++ b/src/zunglq.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunglq_param.jdf
+++ b/src/zunglq_param.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.

--- a/src/zunglq_param.jdf
+++ b/src/zunglq_param.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunglq_param_wrapper.c
+++ b/src/zunglq_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunglq_param_wrapper.c
+++ b/src/zunglq_param_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunglq_wrapper.c
+++ b/src/zunglq_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunglq_wrapper.c
+++ b/src/zunglq_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zungqr.jdf
+++ b/src/zungqr.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.

--- a/src/zungqr.jdf
+++ b/src/zungqr.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zungqr_param.jdf
+++ b/src/zungqr_param.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.

--- a/src/zungqr_param.jdf
+++ b/src/zungqr_param.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013-2016 Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zungqr_param_wrapper.c
+++ b/src/zungqr_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zungqr_param_wrapper.c
+++ b/src/zungqr_param_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zungqr_wrapper.c
+++ b/src/zungqr_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zungqr_wrapper.c
+++ b/src/zungqr_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_LC.jdf
+++ b/src/zunmlq_LC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_LC.jdf
+++ b/src/zunmlq_LC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_LN.jdf
+++ b/src/zunmlq_LN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_LN.jdf
+++ b/src/zunmlq_LN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_RC.jdf
+++ b/src/zunmlq_RC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_RC.jdf
+++ b/src/zunmlq_RC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_RN.jdf
+++ b/src/zunmlq_RN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_RN.jdf
+++ b/src/zunmlq_RN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_param_LC.jdf
+++ b/src/zunmlq_param_LC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_param_LC.jdf
+++ b/src/zunmlq_param_LC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_param_LN.jdf
+++ b/src/zunmlq_param_LN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_param_LN.jdf
+++ b/src/zunmlq_param_LN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_param_RC.jdf
+++ b/src/zunmlq_param_RC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_param_RC.jdf
+++ b/src/zunmlq_param_RC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_param_RN.jdf
+++ b/src/zunmlq_param_RN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmlq_param_RN.jdf
+++ b/src/zunmlq_param_RN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_param_wrapper.c
+++ b/src/zunmlq_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zunmlq_wrapper.c
+++ b/src/zunmlq_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmlq_wrapper.c
+++ b/src/zunmlq_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_LC.jdf
+++ b/src/zunmqr_LC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_LC.jdf
+++ b/src/zunmqr_LC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_LN.jdf
+++ b/src/zunmqr_LN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_LN.jdf
+++ b/src/zunmqr_LN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_RC.jdf
+++ b/src/zunmqr_RC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_RC.jdf
+++ b/src/zunmqr_RC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_RN.jdf
+++ b/src/zunmqr_RN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_RN.jdf
+++ b/src/zunmqr_RN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_param_LC.jdf
+++ b/src/zunmqr_param_LC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_param_LC.jdf
+++ b/src/zunmqr_param_LC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_param_LN.jdf
+++ b/src/zunmqr_param_LN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_param_LN.jdf
+++ b/src/zunmqr_param_LN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_param_RC.jdf
+++ b/src/zunmqr_param_RC.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_param_RC.jdf
+++ b/src/zunmqr_param_RC.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_param_RN.jdf
+++ b/src/zunmqr_param_RN.jdf
@@ -4,8 +4,6 @@ extern "C" %{
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
- *
  *
  * @precisions normal z -> s d c
  *

--- a/src/zunmqr_param_RN.jdf
+++ b/src/zunmqr_param_RN.jdf
@@ -1,6 +1,6 @@
 extern "C" %{
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation. All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_param_wrapper.c
+++ b/src/zunmqr_param_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2020 The University of Tennessee and The University
+ * Copyright (c) 2010-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/src/zunmqr_wrapper.c
+++ b/src/zunmqr_wrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.

--- a/src/zunmqr_wrapper.c
+++ b/src/zunmqr_wrapper.c
@@ -3,7 +3,6 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2013      Inria. All rights reserved.
- * $COPYRIGHT
  *
  * @precisions normal z -> s d c
  *

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2009-2023 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 if(NOT TARGET dplasma_tests_common)
   add_library(dplasma_tests_common OBJECT common.c)
   target_include_directories(dplasma_tests_common

--- a/tests/RulesTestings.cmake
+++ b/tests/RulesTestings.cmake
@@ -1,12 +1,7 @@
+#
 # Copyright (c) 2009-2019 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-#
-# $COPYRIGHT$
-#
-# Additional copyrights may follow
-#
-# $HEADER$
 #
 
 include(PrecisionGenerator)

--- a/tests/Testings.cmake
+++ b/tests/Testings.cmake
@@ -1,4 +1,9 @@
 #
+# Copyright (c) 2010-2024 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
+#
 # A more compact representation of the DPLASMA tests. We can compose any number
 # of tests, by providing the epilogue in ALL_TESTS and have the corresponding
 # OPTION_** defined to the extra options necessary to run that particular flavor

--- a/tests/TestsQRPivgen.cmake
+++ b/tests/TestsQRPivgen.cmake
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2012-2019 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+#
 set(alltreel 0 1 2 3 )    # --treel Option for local tree
 set(alltreeh 0 1 2 3 4 )  # --treeh Option for distributed tree
 set(allP 3 5 7 8)         # --qr_p  Fix the size of the distributed tree

--- a/tests/butterfly.c
+++ b/tests/butterfly.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2012-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include "dplasma.h"
 #include <stdint.h>
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/common_timing.h
+++ b/tests/common_timing.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2010-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #ifndef TIMING_H
 #define TIMING_H
 

--- a/tests/testing_info.c
+++ b/tests/testing_info.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021      The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ */
+
 #include <stdio.h>
 #include <string.h>
 #include "utils/dplasma_info.h"

--- a/tests/testing_zgeadd.c
+++ b/tests/testing_zgeadd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgemm.c
+++ b/tests/testing_zgemm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgeqrf.c
+++ b/tests/testing_zgeqrf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 The University of Tennessee and The University
+ * Copyright (c) 2011-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgeqrf_dtd.c
+++ b/tests/testing_zgeqrf_dtd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023 The University of Tennessee and The University
+ * Copyright (c) 2015-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgeqrf_dtd_untied.c
+++ b/tests/testing_zgeqrf_dtd_untied.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023 The University of Tennessee and The University
+ * Copyright (c) 2015-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgeqrf_rd.c
+++ b/tests/testing_zgeqrf_rd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgesv_incpiv.c
+++ b/tests/testing_zgesv_incpiv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgetrf_1d.c
+++ b/tests/testing_zgetrf_1d.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgetrf_nopiv.c
+++ b/tests/testing_zgetrf_nopiv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgetrf_ptgpanel.c
+++ b/tests/testing_zgetrf_ptgpanel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zgetrf_qrf.c
+++ b/tests/testing_zgetrf_qrf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2021 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zhbrdt.c
+++ b/tests/testing_zhbrdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 The University of Tennessee and The University
+ * Copyright (c) 2011-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zhebut.c
+++ b/tests/testing_zhebut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2014 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zhemm.c
+++ b/tests/testing_zhemm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zher2k.c
+++ b/tests/testing_zher2k.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zherk.c
+++ b/tests/testing_zherk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zlange.c
+++ b/tests/testing_zlange.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zlanm2.c
+++ b/tests/testing_zlanm2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zpivgen.c
+++ b/tests/testing_zpivgen.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zpoinv.c
+++ b/tests/testing_zpoinv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zposv.c
+++ b/tests/testing_zposv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zpotrf.c
+++ b/tests/testing_zpotrf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2023 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zpotrf_dtd_untied.c
+++ b/tests/testing_zpotrf_dtd_untied.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023 The University of Tennessee and The University
+ * Copyright (c) 2015-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zprint.c
+++ b/tests/testing_zprint.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zsymm.c
+++ b/tests/testing_zsymm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zsyr2k.c
+++ b/tests/testing_zsyr2k.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zsyrk.c
+++ b/tests/testing_zsyrk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_ztrmm.c
+++ b/tests/testing_ztrmm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_ztrsm.c
+++ b/tests/testing_ztrsm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_ztrtri.c
+++ b/tests/testing_ztrtri.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zunmlq.c
+++ b/tests/testing_zunmlq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zunmlq_hqr.c
+++ b/tests/testing_zunmlq_hqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zunmlq_systolic.c
+++ b/tests/testing_zunmlq_systolic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zunmqr.c
+++ b/tests/testing_zunmqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zunmqr_hqr.c
+++ b/tests/testing_zunmqr_hqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tests/testing_zunmqr_systolic.c
+++ b/tests/testing_zunmqr_systolic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *

--- a/tools/PrecisionGenerator/PrecisionGenerator.cmake
+++ b/tools/PrecisionGenerator/PrecisionGenerator.cmake
@@ -1,12 +1,7 @@
+#
 # Copyright (c) 2009-2023 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-#
-# $COPYRIGHT$
-#
-# Additional copyrights may follow
-#
-# $HEADER$
 #
 
 #

--- a/tools/cscalapack/common.h
+++ b/tools/cscalapack/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.

--- a/tools/cscalapack/pdgebrd.c
+++ b/tools/cscalapack/pdgebrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020 The University of Tennessee and The University
+ * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tools/cscalapack/pdgemm.c
+++ b/tools/cscalapack/pdgemm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.

--- a/tools/cscalapack/pdgetrf.c
+++ b/tools/cscalapack/pdgetrf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2017 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.

--- a/tools/cscalapack/pdpotrf.c
+++ b/tools/cscalapack/pdpotrf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2017 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.

--- a/tools/cscalapack/pdpotri.c
+++ b/tools/cscalapack/pdpotri.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2017 The University of Tennessee and The University
+ * Copyright (c) 2009-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.

--- a/tools/cscalapack/pdsyev.c
+++ b/tools/cscalapack/pdsyev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 The University of Tennessee and The University
+ * Copyright (c) 2013-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  */

--- a/tools/cscalapack/pdtrmm.c
+++ b/tools/cscalapack/pdtrmm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.

--- a/tools/cscalapack/pdtrsm.c
+++ b/tools/cscalapack/pdtrsm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2020 The University of Tennessee and The University
+ * Copyright (c) 2009-2022 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2010      University of Denver, Colorado.


### PR DESCRIPTION
Cumulative update to copyrights and authors based on git/hg history and parsec contrib/check-copyright.sh script output. 