### PR TITLE
dtd wrappers: cublas fill mode was not set correctly

### DIFF
--- a/src/dtd_wrappers/ztrsm.c
+++ b/src/dtd_wrappers/ztrsm.c
@@ -52,11 +52,6 @@ parsec_core_ztrsm_cuda(parsec_device_gpu_module_t* gpu_device,
     Ag = parsec_dtd_get_dev_ptr(this_task, 0);
     Cg = parsec_dtd_get_dev_ptr(this_task, 1);
 
-    dplasma_cublas_side(side);
-    dplasma_cublas_fill(uplo);
-    dplasma_cublas_op(trans);
-    dplasma_cublas_diag(diag);
-
     handles = parsec_info_get(&gpu_stream->infos, dplasma_dtd_cuda_infoid);
 
 #if defined(PRECISION_z) || defined(PRECISION_c)
@@ -77,7 +72,7 @@ parsec_core_ztrsm_cuda(parsec_device_gpu_module_t* gpu_device,
     parsec_cuda_exec_stream_t* cuda_stream = (parsec_cuda_exec_stream_t*)gpu_stream;
     cublasSetStream( handles->cublas_handle, cuda_stream->cuda_stream );
     status = cublasZtrsm(handles->cublas_handle,
-                          side, uplo, trans, diag,
+                          dplasma_cublas_side(side), dplasma_cublas_fill(uplo), dplasma_cublas_op(trans), dplasma_cublas_diag(diag),
                           m, n, &alphag,
                           (cuDoubleComplex*)Ag, lda,
                           (cuDoubleComplex*)Cg, ldc);

--- a/src/zpotrf_wrapper.c
+++ b/src/zpotrf_wrapper.c
@@ -69,19 +69,13 @@ static void *zpotrf_create_cuda_workspace(void *obj, void *user)
     int mb = tp->_g_descA->mb;
     int nb = tp->_g_descA->nb;
     size_t elt_size = sizeof(cuDoubleComplex);
-    cublasFillMode_t cublas_uplo;
     dplasma_enum_t uplo = tp->_g_uplo;
-
-    if( PlasmaLower == uplo )
-        cublas_uplo = CUBLAS_FILL_MODE_LOWER;
-    if( PlasmaUpper == uplo )
-        cublas_uplo = CUBLAS_FILL_MODE_UPPER;
 
     status = cusolverDnCreate(&cusolverDnHandle);
     assert(CUSOLVER_STATUS_SUCCESS == status);
     (void)status;
 
-    status = cusolverDnDpotrf_bufferSize(cusolverDnHandle, cublas_uplo, nb, NULL, mb, &workspace_size);
+    status = cusolverDnDpotrf_bufferSize(cusolverDnHandle, dplasma_cublas_fill(uplo), nb, NULL, mb, &workspace_size);
     assert(CUSOLVER_STATUS_SUCCESS == status);
 
     cusolverDnDestroy(cusolverDnHandle);


### PR DESCRIPTION
This causes failures in the DTD GPU testers. 