### PR TITLE
Add --uplo command line parameter, use lower by default in all cases

### DIFF
--- a/tests/common.c
+++ b/tests/common.c
@@ -54,9 +54,9 @@ char *PARSEC_SCHED_NAME[] = {
 MPI_Datatype SYNCHRO = MPI_BYTE;
 #endif  /* PARSEC_HAVE_MPI */
 
-const int   side[2]  = { dplasmaLeft,    dplasmaRight };
-const int   uplo[2]  = { dplasmaUpper,   dplasmaLower };
-const int   diag[2]  = { dplasmaNonUnit, dplasmaUnit  };
+const int   sides[2]  = { dplasmaLeft,    dplasmaRight };
+const int   uplos[2]  = { dplasmaUpper,   dplasmaLower };
+const int   diags[2]  = { dplasmaNonUnit, dplasmaUnit  };
 const int   trans[3] = { dplasmaNoTrans, dplasmaTrans, dplasmaConjTrans };
 const int   norms[4] = { dplasmaMaxNorm, dplasmaOneNorm, dplasmaInfNorm, dplasmaFrobeniusNorm };
 
@@ -97,6 +97,7 @@ void print_usage(void)
             " -s --SMB --kp     : repetitions in the process grid row cyclicity (formerly supertiles) (default: 1)\n"
             " -S --SNB --kq     : repetitions in the process grid column cyclicity (formerly supertiles) (default: 1)\n"
             " -z --HNB --HMB    : Inner NB/MB used for recursive algorithms (default: MB)\n"
+            " -u --uplo         : upper/lower triangular matrix (when applicable)\n"
             " -x --check        : verify the results\n"
             " -X --check_inv    : verify the results against the inverse\n"
             " -b --sync         : call the step by step version of the algorithm if exists\n"
@@ -219,6 +220,8 @@ static struct option long_options[] =
     {"kq",          required_argument,  0, 'S'},
     {"SNB",         required_argument,  0, 'S'},
     {"S",           required_argument,  0, 'S'},
+    {"uplo",        required_argument,  0, 'u'},
+    {"u",           required_argument,  0, 'u'},
     {"check",       no_argument,        0, 'x'},
     {"x",           no_argument,        0, 'x'},
     {"check_inv",   no_argument,        0, 'X'},
@@ -342,6 +345,17 @@ static void read_arguments(int *_argc, char*** _argv, int* iparam)
             case 'T': iparam[IPARAM_NB] = atoi(optarg); break;
             case 's': iparam[IPARAM_KP] = atoi(optarg); break;
             case 'S': iparam[IPARAM_KQ] = atoi(optarg); break;
+            case 'u':
+                if('u' == optarg[0] || 'U' == optarg[0]) {
+                    iparam[IPARAM_UPLO] = dplasmaUpper;
+                    break;
+                }
+                if('l' == optarg[0] || 'L' == optarg[0]) {
+                    iparam[IPARAM_UPLO] = dplasmaLower;
+                    break;
+                }
+                fprintf(stderr, "#!!!!! malformed uplo value %s (accepted: u, U, l, L). Value ignored!\n", optarg);
+                break;
 
             case 'X': iparam[IPARAM_CHECKINV] = 1;
                       /* Fall through */
@@ -598,6 +612,7 @@ void iparam_default_facto(int* iparam)
     iparam[IPARAM_LDA] = -'m';
     iparam[IPARAM_LDB] = 0;
     iparam[IPARAM_LDC] = 0;
+    iparam[IPARAM_UPLO] = dplasmaLower;
 }
 
 void iparam_default_solve(int* iparam)

--- a/tests/common.h
+++ b/tests/common.h
@@ -59,6 +59,7 @@ enum iparam_t {
   IPARAM_KP,           /* Number of rows repetititions in a k-cyclic distribution */
   IPARAM_HMB,          /* Small MB for recursive hdags */
   IPARAM_HNB,          /* Small NB for recursive hdags */
+  IPARAM_UPLO,         /* Upper/Lower triangular */
   IPARAM_CHECK,        /* Checking activated or not         */
   IPARAM_CHECKINV,     /* Inverse Checking activated or not */
   IPARAM_ASYNC,        /* Bench the asynchronous version    */
@@ -119,6 +120,7 @@ void iparam_default_ibnbmb(int* iparam, int ib, int nb, int mb);
     int MT    = (M%MB==0) ? (M/MB) : (M/MB+1);                          \
     int NT    = (N%NB==0) ? (N/NB) : (N/NB+1);                          \
     int KT    = (K%MB==0) ? (K/MB) : (K/MB+1);                          \
+    int uplo  = iparam[IPARAM_UPLO];                                    \
     int check = iparam[IPARAM_CHECK];                                   \
     int check_inv = iparam[IPARAM_CHECKINV];                            \
     int loud  = iparam[IPARAM_VERBOSE];                                 \
@@ -130,7 +132,7 @@ void iparam_default_ibnbmb(int* iparam, int ib, int nb, int mb);
     (void)rank;(void)nodes;(void)cores;(void)gpus;(void)P;(void)Q;(void)M;(void)N;(void)K;(void)NRHS; \
     (void)LDA;(void)LDB;(void)LDC;(void)IB;(void)MB;(void)NB;(void)MT;(void)NT;(void)KT; \
     (void)KP;(void)KQ;(void)IP;(void)JQ;(void)HMB;(void)HNB;(void)check;(void)loud;(void)async; \
-    (void)scheduler;(void)butterfly_level;(void)check_inv;(void)random_seed;(void)matrix_init;(void)nruns;
+    (void)scheduler;(void)butterfly_level;(void)uplo;(void)check_inv;(void)random_seed;(void)matrix_init;(void)nruns;
 
 /* Define a double type which not pass through the precision generation process */
 typedef double DagDouble_t;
@@ -153,9 +155,9 @@ typedef double DagDouble_t;
 extern MPI_Datatype SYNCHRO;
 #endif  /* PARSEC_HAVE_MPI */
 
-extern const int side[2];
-extern const int uplo[2];
-extern const int diag[2];
+extern const int sides[2];
+extern const int uplos[2];
+extern const int diags[2];
 extern const int trans[3];
 extern const int norms[4];
 extern const char *sidestr[2];
@@ -219,6 +221,7 @@ static inline int min(int a, int b) { return a < b ? a : b; }
     PROFILING_SAVE_iINFO("PARAM_KP", iparam[IPARAM_KQ]);                \
     PROFILING_SAVE_iINFO("PARAM_KQ", iparam[IPARAM_KP]);                \
     PROFILING_SAVE_iINFO("PARAM_HNB", iparam[IPARAM_HNB]);              \
+    PROFILING_SAVE_iINFO("PARAM_UPLO", iparam[IPARAM_UPLO]);            \
     PROFILING_SAVE_iINFO("PARAM_CHECK", iparam[IPARAM_CHECK]);          \
     PROFILING_SAVE_iINFO("PARAM_CHECKINV", iparam[IPARAM_CHECKINV]);    \
     PROFILING_SAVE_iINFO("PARAM_VERBOSE", iparam[IPARAM_VERBOSE]);      \

--- a/tests/testing_zgeadd.c
+++ b/tests/testing_zgeadd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -104,7 +104,7 @@ int main(int argc, char ** argv)
 
             /* Create GEMM PaRSEC */
             if(loud) printf("Compute ... ... ");
-            dplasma_ztradd(parsec, uplo[u], trans[tA],
+            dplasma_ztradd(parsec, uplos[u], trans[tA],
                            (dplasma_complex64_t)alpha,
                            (parsec_tiled_matrix_t *)&dcA,
                            (dplasma_complex64_t)beta,
@@ -113,7 +113,7 @@ int main(int argc, char ** argv)
 
             /* Check the solution */
             info_solution = check_tr_solution( parsec, (rank == 0) ? loud : 0,
-                                               uplo[u], trans[tA],
+                                               uplos[u], trans[tA],
                                                alpha, Am, An,
                                                (parsec_tiled_matrix_t *)&dcA,
                                                beta,  M,  N,

--- a/tests/testing_zhebut.c
+++ b/tests/testing_zhebut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -29,7 +29,6 @@ int main(int argc, char ** argv)
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
     int ret = 0;
-    dplasma_enum_t uplo = dplasmaLower;
     dplasma_complex64_t *U_but_vec;
     DagDouble_t time_butterfly, time_facto, time_total;
 

--- a/tests/testing_zheev.c
+++ b/tests/testing_zheev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 The University of Tennessee and The University
+ * Copyright (c) 2011-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
-    dplasma_enum_t uplo = dplasmaLower;
     int j;
     int rc;
 

--- a/tests/testing_zhemm.c
+++ b/tests/testing_zhemm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -65,7 +65,6 @@ int main(int argc, char ** argv)
     if(!check)
     {
         dplasma_enum_t side  = dplasmaLeft;
-        dplasma_enum_t uplo  = dplasmaLower;
         int Am = ( side == dplasmaLeft ? M : N );
         LDA = max(LDA, Am);
 
@@ -103,7 +102,7 @@ int main(int argc, char ** argv)
 
         for (s=0; s<2; s++) {
             /* initializing matrix structure */
-            int Am = ( side[s] == dplasmaLeft ? M : N );
+            int Am = ( sides[s] == dplasmaLeft ? M : N );
             LDA = max(LDA, Am);
 
             for (u=0; u<2; u++) {
@@ -111,17 +110,17 @@ int main(int argc, char ** argv)
                 PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
                     parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                                rank, MB, NB, LDA, Am, 0, 0,
-                                               Am, Am, P, nodes/P, uplo[u]));
+                                               Am, Am, P, nodes/P, uplos[u]));
 
                 if (loud > 2) printf("Generate matrices ... ");
-                dplasma_zplghe( parsec, 0., uplo[u], (parsec_tiled_matrix_t *)&dcA, Aseed);
+                dplasma_zplghe( parsec, 0., uplos[u], (parsec_tiled_matrix_t *)&dcA, Aseed);
                 dplasma_zlacpy( parsec, dplasmaUpperLower,
                                 (parsec_tiled_matrix_t *)&dcC2, (parsec_tiled_matrix_t *)&dcC );
                 if (loud > 2) printf("Done\n");
 
                 /* Compute */
                 if (loud > 2) printf("Compute ... ... ");
-                dplasma_zhemm(parsec, side[s], uplo[u],
+                dplasma_zhemm(parsec, sides[s], uplos[u],
                               alpha, (parsec_tiled_matrix_t *)&dcA,
                                      (parsec_tiled_matrix_t *)&dcB,
                               beta,  (parsec_tiled_matrix_t *)&dcC);
@@ -129,7 +128,7 @@ int main(int argc, char ** argv)
 
                 /* Check the solution */
                 info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                               side[s], uplo[u],
+                                               sides[s], uplos[u],
                                                alpha, Am, Am, Aseed,
                                                beta,  M,  N,  Bseed, Cseed,
                                                &dcC);

--- a/tests/testing_zher2k.c
+++ b/tests/testing_zher2k.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -42,7 +42,6 @@ int main(int argc, char ** argv)
 
     if(!check)
     {
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t trans = dplasmaNoTrans;
         int Am, An;
 
@@ -102,7 +101,7 @@ int main(int argc, char ** argv)
             PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
                 parsec_matrix_sym_block_cyclic, (&dcC, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                            rank, MB, NB, LDC, N, 0, 0,
-                                           N, N, P, nodes/P, uplo[u]));
+                                           N, N, P, nodes/P, uplos[u]));
 
             for (t=0; t<2; t++) {
 #if defined(PRECISION_z) || defined(PRECISION_c)
@@ -126,12 +125,12 @@ int main(int argc, char ** argv)
                 if (loud > 2) printf("Generate matrices ... ");
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
-                dplasma_zplghe( parsec, 0., uplo[u], (parsec_tiled_matrix_t *)&dcC, Cseed);
+                dplasma_zplghe( parsec, 0., uplos[u], (parsec_tiled_matrix_t *)&dcC, Cseed);
                 if (loud > 2) printf("Done\n");
 
                 /* Compute */
                 if (loud > 2) printf("Compute ... ... ");
-                dplasma_zher2k(parsec, uplo[u], trans[t],
+                dplasma_zher2k(parsec, uplos[u], trans[t],
                               alpha, (parsec_tiled_matrix_t *)&dcA,
                                      (parsec_tiled_matrix_t *)&dcB,
                               beta,  (parsec_tiled_matrix_t *)&dcC);
@@ -139,7 +138,7 @@ int main(int argc, char ** argv)
 
                 /* Check the solution */
                 info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                               uplo[u], trans[t],
+                                               uplos[u], trans[t],
                                                alpha, Am, An, Aseed, Bseed,
                                                beta,  N,  N,  Cseed,
                                                &dcC);

--- a/tests/testing_zherk.c
+++ b/tests/testing_zherk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -41,7 +41,6 @@ int main(int argc, char ** argv)
 
     if(!check)
     {
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t trans = dplasmaNoTrans;
         int Am = ( trans == dplasmaNoTrans ? N : K );
         int An = ( trans == dplasmaNoTrans ? K : N );
@@ -99,7 +98,7 @@ int main(int argc, char ** argv)
             PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
                 parsec_matrix_sym_block_cyclic, (&dcC, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                            rank, MB, NB, LDC, N, 0, 0,
-                                           N, N, P, nodes/P, uplo[u]));
+                                           N, N, P, nodes/P, uplos[u]));
 
             for (t=0; t<2; t++) {
 #if defined(PRECISION_z) || defined(PRECISION_c)
@@ -117,20 +116,20 @@ int main(int argc, char ** argv)
 
                 if (loud > 2) printf("Generate matrices ... ");
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
-                dplasma_zlacpy( parsec, uplo[u],
+                dplasma_zlacpy( parsec, uplos[u],
                                 (parsec_tiled_matrix_t *)&dcC2, (parsec_tiled_matrix_t *)&dcC );
                 if (loud > 2) printf("Done\n");
 
                 /* Compute */
                 if (loud > 2) printf("Compute ... ... ");
-                dplasma_zherk(parsec, uplo[u], trans[t],
+                dplasma_zherk(parsec, uplos[u], trans[t],
                               alpha, (parsec_tiled_matrix_t *)&dcA,
                               beta,  (parsec_tiled_matrix_t *)&dcC);
                 if (loud > 2) printf("Done\n");
 
                 /* Check the solution */
                 info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                               uplo[u], trans[t],
+                                               uplos[u], trans[t],
                                                alpha, Am, An, Aseed,
                                                beta,  N,  N,  Cseed,
                                                &dcC);

--- a/tests/testing_zlange.c
+++ b/tests/testing_zlange.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -145,7 +145,7 @@ int main(int argc, char ** argv)
                         printf("***************************************************\n");
                     }
                     if(loud > 2) printf("+++ Computing norm %s ... ", normsstr[i]);
-                    normdag = dplasma_zlantr(parsec, norms[i], uplo[u], diag[d],
+                    normdag = dplasma_zlantr(parsec, norms[i], uplos[u], diags[d],
                                              (parsec_tiled_matrix_t *)&dcA);
 
                     if ( rank == 0 ) {
@@ -220,16 +220,16 @@ int main(int argc, char ** argv)
             PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
                 parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                            rank, MB, NB, LDA, N, 0, 0,
-                                           M, N, P, nodes/P, uplo[u]));
+                                           M, N, P, nodes/P, uplos[u]));
 
-            dplasma_zplgsy( parsec, 0., uplo[u], (parsec_tiled_matrix_t *)&dcA, 3872);
+            dplasma_zplgsy( parsec, 0., uplos[u], (parsec_tiled_matrix_t *)&dcA, 3872);
 
             for(i=0; i<4; i++) {
                 if ( rank == 0 ) {
                     printf("***************************************************\n");
                 }
                 if(loud > 2) printf("+++ Computing norm %s ... ", normsstr[i]);
-                normdag = dplasma_zlansy(parsec, norms[i], uplo[u],
+                normdag = dplasma_zlansy(parsec, norms[i], uplos[u],
                                          (parsec_tiled_matrix_t *)&dcA);
 
                 if ( rank == 0 ) {
@@ -300,16 +300,16 @@ int main(int argc, char ** argv)
             PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
                 parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                            rank, MB, NB, LDA, N, 0, 0,
-                                           M, N, P, nodes/P, uplo[u]));
+                                           M, N, P, nodes/P, uplos[u]));
 
-            dplasma_zplghe( parsec, 0., uplo[u], (parsec_tiled_matrix_t *)&dcA, 3872);
+            dplasma_zplghe( parsec, 0., uplos[u], (parsec_tiled_matrix_t *)&dcA, 3872);
 
             for(i=0; i<4; i++) {
                 if ( rank == 0 ) {
                     printf("***************************************************\n");
                 }
                 if(loud > 2) printf("+++ Computing norm %s ... ", normsstr[i]);
-                normdag = dplasma_zlanhe(parsec, norms[i], uplo[u],
+                normdag = dplasma_zlanhe(parsec, norms[i], uplos[u],
                                          (parsec_tiled_matrix_t *)&dcA);
 
                 if ( rank == 0 ) {

--- a/tests/testing_zpoinv.c
+++ b/tests/testing_zpoinv.c
@@ -18,7 +18,6 @@ int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
-    dplasma_enum_t uplo = dplasmaLower;
     int info = 0;
     int ret = 0;
 

--- a/tests/testing_zposv.c
+++ b/tests/testing_zposv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -58,7 +58,7 @@ int main(int argc, char ** argv)
     if(loud > 2) printf("Done\n");
 
     for ( u=0; u<2; u++) {
-        if ( uplo[u] == dplasmaUpper ) {
+        if ( uplos[u] == dplasmaUpper ) {
             t1 = dplasmaConjTrans; t2 = dplasmaNoTrans;
         } else {
             t1 = dplasmaNoTrans; t2 = dplasmaConjTrans;
@@ -67,7 +67,7 @@ int main(int argc, char ** argv)
         PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
             parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                        rank, MB, NB, LDA, N, 0, 0,
-                                       N, N, P, nodes/P, uplo[u]));
+                                       N, N, P, nodes/P, uplos[u]));
 
         /*********************************************************************
          *               First Check ( ZPOSV )
@@ -76,7 +76,7 @@ int main(int argc, char ** argv)
             printf("***************************************************\n");
         }
         /* Create A and X */
-        dplasma_zlacpy( parsec, uplo[u],
+        dplasma_zlacpy( parsec, uplos[u],
                         (parsec_tiled_matrix_t *)&dcA0, (parsec_tiled_matrix_t *)&dcA );
         dplasma_zplrnt( parsec, 0,
                         (parsec_tiled_matrix_t *)&dcB, 2354);
@@ -85,7 +85,7 @@ int main(int argc, char ** argv)
 
         /* Compute */
         if ( loud > 2 ) printf("Compute ... ... ");
-        info = dplasma_zposv(parsec, uplo[u],
+        info = dplasma_zposv(parsec, uplos[u],
                              (parsec_tiled_matrix_t *)&dcA,
                              (parsec_tiled_matrix_t *)&dcX );
         if ( loud > 2 ) printf("Done\n");
@@ -93,11 +93,11 @@ int main(int argc, char ** argv)
 
         /* Check the factorization */
         if ( info == 0 ) {
-            info_facto = check_zpotrf( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_facto = check_zpotrf( parsec, (rank == 0) ? loud : 0, uplos[u],
                                        (parsec_tiled_matrix_t *)&dcA,
                                        (parsec_tiled_matrix_t *)&dcA0);
 
-            info_solve = check_zaxmb( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_solve = check_zaxmb( parsec, (rank == 0) ? loud : 0, uplos[u],
                                       (parsec_tiled_matrix_t *)&dcA0,
                                       (parsec_tiled_matrix_t *)&dcB,
                                       (parsec_tiled_matrix_t *)&dcX);
@@ -121,7 +121,7 @@ int main(int argc, char ** argv)
         }
 
         /* Create A and X */
-        dplasma_zlacpy( parsec, uplo[u],
+        dplasma_zlacpy( parsec, uplos[u],
                         (parsec_tiled_matrix_t *)&dcA0, (parsec_tiled_matrix_t *)&dcA );
         dplasma_zplrnt( parsec, 0,
                         (parsec_tiled_matrix_t *)&dcB, 2354);
@@ -130,10 +130,10 @@ int main(int argc, char ** argv)
 
         /* Compute */
         if ( loud > 2 ) printf("Compute ... ... ");
-        info = dplasma_zpotrf(parsec, uplo[u],
+        info = dplasma_zpotrf(parsec, uplos[u],
                               (parsec_tiled_matrix_t *)&dcA );
         if ( info == 0 ) {
-            dplasma_zpotrs(parsec, uplo[u],
+            dplasma_zpotrs(parsec, uplos[u],
                            (parsec_tiled_matrix_t *)&dcA,
                            (parsec_tiled_matrix_t *)&dcX );
         }
@@ -142,11 +142,11 @@ int main(int argc, char ** argv)
 
         /* Check the solution */
         if ( info == 0 ) {
-            info_facto = check_zpotrf( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_facto = check_zpotrf( parsec, (rank == 0) ? loud : 0, uplos[u],
                                        (parsec_tiled_matrix_t *)&dcA,
                                        (parsec_tiled_matrix_t *)&dcA0 );
 
-            info_solve = check_zaxmb( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_solve = check_zaxmb( parsec, (rank == 0) ? loud : 0, uplos[u],
                                       (parsec_tiled_matrix_t *)&dcA0,
                                       (parsec_tiled_matrix_t *)&dcB,
                                       (parsec_tiled_matrix_t *)&dcX );
@@ -170,7 +170,7 @@ int main(int argc, char ** argv)
         }
 
         /* Create A and X */
-        dplasma_zlacpy( parsec, uplo[u],
+        dplasma_zlacpy( parsec, uplos[u],
                         (parsec_tiled_matrix_t *)&dcA0, (parsec_tiled_matrix_t *)&dcA );
         dplasma_zplrnt( parsec, 0,
                         (parsec_tiled_matrix_t *)&dcB, 2354);
@@ -179,12 +179,12 @@ int main(int argc, char ** argv)
 
         /* Compute */
         if ( loud > 2 ) printf("Compute ... ... ");
-        info = dplasma_zpotrf(parsec, uplo[u], (parsec_tiled_matrix_t *)&dcA );
+        info = dplasma_zpotrf(parsec, uplos[u], (parsec_tiled_matrix_t *)&dcA );
         if ( info == 0 ) {
-            dplasma_ztrsm(parsec, dplasmaLeft, uplo[u], t1, dplasmaNonUnit, 1.0,
+            dplasma_ztrsm(parsec, dplasmaLeft, uplos[u], t1, dplasmaNonUnit, 1.0,
                           (parsec_tiled_matrix_t *)&dcA,
                           (parsec_tiled_matrix_t *)&dcX);
-            dplasma_ztrsm(parsec, dplasmaLeft, uplo[u], t2, dplasmaNonUnit, 1.0,
+            dplasma_ztrsm(parsec, dplasmaLeft, uplos[u], t2, dplasmaNonUnit, 1.0,
                           (parsec_tiled_matrix_t *)&dcA,
                           (parsec_tiled_matrix_t *)&dcX);
         }
@@ -193,11 +193,11 @@ int main(int argc, char ** argv)
 
         /* Check the solution */
         if ( info == 0 ) {
-            info_facto = check_zpotrf( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_facto = check_zpotrf( parsec, (rank == 0) ? loud : 0, uplos[u],
                                        (parsec_tiled_matrix_t *)&dcA,
                                        (parsec_tiled_matrix_t *)&dcA0 );
 
-            info_solve = check_zaxmb( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_solve = check_zaxmb( parsec, (rank == 0) ? loud : 0, uplos[u],
                                       (parsec_tiled_matrix_t *)&dcA0,
                                       (parsec_tiled_matrix_t *)&dcB,
                                       (parsec_tiled_matrix_t *)&dcX );
@@ -222,22 +222,22 @@ int main(int argc, char ** argv)
         }
 
         /* Create A and X */
-        dplasma_zlacpy( parsec, uplo[u],
+        dplasma_zlacpy( parsec, uplos[u],
                         (parsec_tiled_matrix_t *)&dcA0, (parsec_tiled_matrix_t *)&dcA );
 
         /* Compute */
         if ( loud > 2 ) printf("Compute ... ... ");
-        info = dplasma_zpotrf(parsec, uplo[u], (parsec_tiled_matrix_t *)&dcA );
+        info = dplasma_zpotrf(parsec, uplos[u], (parsec_tiled_matrix_t *)&dcA );
 
         if ( info == 0 ) {
-            info = dplasma_zpotri(parsec, uplo[u], (parsec_tiled_matrix_t *)&dcA );
+            info = dplasma_zpotri(parsec, uplos[u], (parsec_tiled_matrix_t *)&dcA );
         }
         if ( loud > 2 ) printf("Done\n");
         if ( info != 0 ) printf("%d: Info = %d\n", rank, info);
 
         /* Check the solution */
         if ( info == 0 ) {
-            info_solve = check_zpoinv( parsec, (rank == 0) ? loud : 0, uplo[u],
+            info_solve = check_zpoinv( parsec, (rank == 0) ? loud : 0, uplos[u],
                                        (parsec_tiled_matrix_t *)&dcA0,
                                        (parsec_tiled_matrix_t *)&dcA);
         }

--- a/tests/testing_zpotrf.c
+++ b/tests/testing_zpotrf.c
@@ -19,7 +19,6 @@ int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
-    dplasma_enum_t uplo = dplasmaLower;
     int info = 0;
     int ret = 0;
 

--- a/tests/testing_zpotrf_dtd.c
+++ b/tests/testing_zpotrf_dtd.c
@@ -25,7 +25,6 @@ int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
-    int uplo = dplasmaUpper;
     int info = 0;
     int ret = 0;
 

--- a/tests/testing_zpotrf_dtd_untied.c
+++ b/tests/testing_zpotrf_dtd_untied.c
@@ -333,7 +333,6 @@ int main(int argc, char **argv)
 {
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
-    int uplo = dplasmaUpper;
     int info = 0;
     int ret = 0;
 

--- a/tests/testing_zprint.c
+++ b/tests/testing_zprint.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -16,7 +16,6 @@ int main(int argc, char ** argv)
 {
     parsec_context_t* parsec;
     int iparam[IPARAM_SIZEOF];
-    dplasma_enum_t uplo = dplasmaLower;
     int i, info, ret = 0;
 
     /* Set defaults for non argv iparams */

--- a/tests/testing_zsymm.c
+++ b/tests/testing_zsymm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -70,7 +70,6 @@ int main(int argc, char ** argv)
     if(!check)
     {
         dplasma_enum_t side  = dplasmaLeft;
-        dplasma_enum_t uplo  = dplasmaLower;
         int Am = ( side == dplasmaLeft ? M : N );
         LDA = max(LDA, Am);
 
@@ -108,7 +107,7 @@ int main(int argc, char ** argv)
 
         for (s=0; s<2; s++) {
             /* initializing matrix structure */
-            int Am = ( side[s] == dplasmaLeft ? M : N );
+            int Am = ( sides[s] == dplasmaLeft ? M : N );
             LDA = max(LDA, Am);
 
             for (u=0; u<2; u++) {
@@ -116,17 +115,17 @@ int main(int argc, char ** argv)
                 PASTE_CODE_ALLOCATE_MATRIX(dcA, 1,
                     parsec_matrix_sym_block_cyclic, (&dcA, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                                rank, MB, NB, LDA, Am, 0, 0,
-                                               Am, Am, P, nodes/P, uplo[u]));
+                                               Am, Am, P, nodes/P, uplos[u]));
 
                 if (loud > 2) printf("Generate matrices ... ");
-                dplasma_zplgsy( parsec, 0., uplo[u], (parsec_tiled_matrix_t *)&dcA, Aseed);
+                dplasma_zplgsy( parsec, 0., uplos[u], (parsec_tiled_matrix_t *)&dcA, Aseed);
                 dplasma_zlacpy( parsec, dplasmaUpperLower,
                                 (parsec_tiled_matrix_t *)&dcC2, (parsec_tiled_matrix_t *)&dcC );
                 if (loud > 2) printf("Done\n");
 
                 /* Compute */
                 if (loud > 2) printf("Compute ... ... ");
-                dplasma_zsymm(parsec, side[s], uplo[u],
+                dplasma_zsymm(parsec, sides[s], uplos[u],
                               (dplasma_complex64_t)alpha, (parsec_tiled_matrix_t *)&dcA,
                                                         (parsec_tiled_matrix_t *)&dcB,
                               (dplasma_complex64_t)beta,  (parsec_tiled_matrix_t *)&dcC);
@@ -134,7 +133,7 @@ int main(int argc, char ** argv)
 
                 /* Check the solution */
                 info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                               side[s], uplo[u],
+                                               sides[s], uplos[u],
                                                alpha, Am, Am, Aseed,
                                                beta,  M,  N,  Bseed, Cseed,
                                                &dcC);

--- a/tests/testing_zsyr2k.c
+++ b/tests/testing_zsyr2k.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -47,7 +47,6 @@ int main(int argc, char ** argv)
 
     if(!check)
     {
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t trans = dplasmaNoTrans;
         int Am, An;
 
@@ -107,7 +106,7 @@ int main(int argc, char ** argv)
             PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
                 parsec_matrix_sym_block_cyclic, (&dcC, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                            rank, MB, NB, LDC, N, 0, 0,
-                                           N, N, P, nodes/P, uplo[u]));
+                                           N, N, P, nodes/P, uplos[u]));
 
             for (t=0; t<2; t++) {
                 /* initializing matrix structure */
@@ -128,12 +127,12 @@ int main(int argc, char ** argv)
                 if (loud > 2) printf("Generate matrices ... ");
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcB, Bseed);
-                dplasma_zplgsy( parsec, 0., uplo[u], (parsec_tiled_matrix_t *)&dcC, Cseed);
+                dplasma_zplgsy( parsec, 0., uplos[u], (parsec_tiled_matrix_t *)&dcC, Cseed);
                 if (loud > 2) printf("Done\n");
 
                 /* Compute */
                 if (loud > 2) printf("Compute ... ... ");
-                dplasma_zsyr2k(parsec, uplo[u], trans[t],
+                dplasma_zsyr2k(parsec, uplos[u], trans[t],
                               alpha, (parsec_tiled_matrix_t *)&dcA,
                                      (parsec_tiled_matrix_t *)&dcB,
                               beta,  (parsec_tiled_matrix_t *)&dcC);
@@ -141,7 +140,7 @@ int main(int argc, char ** argv)
 
                 /* Check the solution */
                 info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                               uplo[u], trans[t],
+                                               uplos[u], trans[t],
                                                alpha, Am, An, Aseed, Bseed,
                                                beta,  N,  N,  Cseed,
                                                &dcC);

--- a/tests/testing_zsyrk.c
+++ b/tests/testing_zsyrk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -40,7 +40,6 @@ int main(int argc, char ** argv)
 
     if(!check)
     {
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t trans = dplasmaNoTrans;
         int Am = ( trans == dplasmaNoTrans ? N : K );
         int An = ( trans == dplasmaNoTrans ? K : N );
@@ -97,7 +96,7 @@ int main(int argc, char ** argv)
             PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
                 parsec_matrix_sym_block_cyclic, (&dcC, PARSEC_MATRIX_COMPLEX_DOUBLE,
                                            rank, MB, NB, LDC, N, 0, 0,
-                                           N, N, P, nodes/P, uplo[u]));
+                                           N, N, P, nodes/P, uplos[u]));
 
             for (t=0; t<2; t++) {
 
@@ -113,20 +112,20 @@ int main(int argc, char ** argv)
 
                 if (loud > 2) printf("Generate matrices ... ");
                 dplasma_zplrnt( parsec, 0, (parsec_tiled_matrix_t *)&dcA, Aseed);
-                dplasma_zlacpy( parsec, uplo[u],
+                dplasma_zlacpy( parsec, uplos[u],
                                 (parsec_tiled_matrix_t *)&dcC2, (parsec_tiled_matrix_t *)&dcC );
                 if (loud > 2) printf("Done\n");
 
                 /* Compute */
                 if (loud > 2) printf("Compute ... ... ");
-                dplasma_zsyrk(parsec, uplo[u], trans[t],
+                dplasma_zsyrk(parsec, uplos[u], trans[t],
                               alpha, (parsec_tiled_matrix_t *)&dcA,
                               beta,  (parsec_tiled_matrix_t *)&dcC);
                 if (loud > 2) printf("Done\n");
 
                 /* Check the solution */
                 info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                               uplo[u], trans[t],
+                                               uplos[u], trans[t],
                                                alpha, Am, An, Aseed,
                                                beta,  N,  N,  Cseed,
                                                &dcC);

--- a/tests/testing_ztrmm.c
+++ b/tests/testing_ztrmm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -55,7 +55,6 @@ int main(int argc, char ** argv)
     if(!check)
     {
         dplasma_enum_t side  = dplasmaLeft;
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t trans = dplasmaNoTrans;
         dplasma_enum_t diag  = dplasmaUnit;
 
@@ -102,7 +101,7 @@ int main(int argc, char ** argv)
 
         for (s=0; s<2; s++) {
             /* Make A square */
-            if (side[s] == dplasmaLeft) {
+            if (sides[s] == dplasmaLeft) {
                 Am = M;
                 dcA = parsec_tiled_matrix_submatrix( (parsec_tiled_matrix_t *)&dcA0, 0, 0, M, M );
             } else {
@@ -132,13 +131,13 @@ int main(int argc, char ** argv)
 
                         /* Compute */
                         printf("Compute ... ... ");
-                        dplasma_ztrmm(parsec, side[s], uplo[u], trans[t], diag[d],
+                        dplasma_ztrmm(parsec, sides[s], uplos[u], trans[t], diags[d],
                                       alpha, dcA, (parsec_tiled_matrix_t *)&dcC);
                         printf("Done\n");
 
                         /* Check the solution */
                         info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                                       side[s], uplo[u], trans[t], diag[d],
+                                                       sides[s], uplos[u], trans[t], diags[d],
                                                        alpha, Am, Am, Aseed,
                                                               M,  N,  Cseed,
                                                        &dcC);

--- a/tests/testing_ztrsm.c
+++ b/tests/testing_ztrsm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -70,7 +70,6 @@ int main(int argc, char ** argv)
     if(!check)
     {
         dplasma_enum_t side  = dplasmaLeft;
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t trans = dplasmaNoTrans;
         dplasma_enum_t diag  = dplasmaUnit;
 
@@ -105,7 +104,7 @@ int main(int argc, char ** argv)
 
         for (s=0; s<2; s++) {
             /* Make A square */
-            if (side[s] == dplasmaLeft) {
+            if (sides[s] == dplasmaLeft) {
                 dcA = parsec_tiled_matrix_submatrix( (parsec_tiled_matrix_t *)&dcA0, 0, 0, M, M );
             } else {
                 dcA = parsec_tiled_matrix_submatrix( (parsec_tiled_matrix_t *)&dcA0, 0, 0, N, N );
@@ -130,13 +129,13 @@ int main(int argc, char ** argv)
                         dplasma_zlacpy( parsec, dplasmaUpperLower,
                                         (parsec_tiled_matrix_t *)&dcC0,
                                         (parsec_tiled_matrix_t *)&dcC );
-                        dplasma_ztrmm(parsec, side[s], uplo[u], trans[t], diag[d], 1./alpha,
+                        dplasma_ztrmm(parsec, sides[s], uplos[u], trans[t], diags[d], 1./alpha,
                                       dcA, (parsec_tiled_matrix_t *)&dcC);
                         printf("Done\n");
 
                         /* Compute */
                         printf("Compute ... ... ");
-                        dplasma_ztrsm(parsec, side[s], uplo[u], trans[t], diag[d], alpha,
+                        dplasma_ztrsm(parsec, sides[s], uplos[u], trans[t], diags[d], alpha,
                                       dcA, (parsec_tiled_matrix_t *)&dcC);
                         printf("Done\n");
 

--- a/tests/testing_ztrtri.c
+++ b/tests/testing_ztrtri.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -57,7 +57,6 @@ int main(int argc, char ** argv)
 
     if(!check)
     {
-        dplasma_enum_t uplo  = dplasmaLower;
         dplasma_enum_t diag  = dplasmaUnit;
         int info = 0;
 
@@ -94,7 +93,7 @@ int main(int argc, char ** argv)
 
                 /* Compute */
                 printf("Compute ... ... ");
-                info = dplasma_ztrtri(parsec, uplo[u], diag[d],
+                info = dplasma_ztrtri(parsec, uplos[u], diags[d],
                                (parsec_tiled_matrix_t *)&dcAinv);
                 printf("Done\n");
 
@@ -104,7 +103,7 @@ int main(int argc, char ** argv)
 
                 } else {
                     info_solution = check_solution(parsec, rank == 0 ? loud : 0,
-                                                   uplo[u], diag[d], Am,
+                                                   uplos[u], diags[d], Am,
                                                    (parsec_tiled_matrix_t*)&dcA,
                                                    (parsec_tiled_matrix_t*)&dcAinv);
                 }

--- a/tests/testing_zunmlq.c
+++ b/tests/testing_zunmlq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -75,8 +75,8 @@ int main(int argc, char ** argv)
 
     for (s=0; s<2; s++) {
 
-        int Cm = (side[s] == dplasmaLeft) ? N : M;
-        int Cn = (side[s] == dplasmaLeft) ? M : N;
+        int Cm = (sides[s] == dplasmaLeft) ? N : M;
+        int Cn = (sides[s] == dplasmaLeft) ? M : N;
         LDC = max(LDC, Cm);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
@@ -103,12 +103,12 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t *)&dcC0,
                             (parsec_tiled_matrix_t *)&dcC);
 
-            dplasma_zunmlq( parsec, side[s], trans[t],
+            dplasma_zunmlq( parsec, sides[s], trans[t],
                             (parsec_tiled_matrix_t *)&dcA,
                             (parsec_tiled_matrix_t *)&dcT,
                             (parsec_tiled_matrix_t *)&dcC);
 
-            if (side[s] == dplasmaLeft ) {
+            if (sides[s] == dplasmaLeft ) {
                 dplasma_zgemm( parsec, trans[t], dplasmaNoTrans,
                                -1., (parsec_tiled_matrix_t *)&dcQ,
                                     (parsec_tiled_matrix_t *)&dcC0,

--- a/tests/testing_zunmlq_hqr.c
+++ b/tests/testing_zunmlq_hqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -148,8 +148,8 @@ int main(int argc, char ** argv)
 
     for (s=0; s<2; s++) {
 
-        int Cm = (side[s] == dplasmaLeft) ? N : M;
-        int Cn = (side[s] == dplasmaLeft) ? M : N;
+        int Cm = (sides[s] == dplasmaLeft) ? N : M;
+        int Cn = (sides[s] == dplasmaLeft) ? M : N;
         LDC = max(LDC, Cm);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
@@ -177,13 +177,13 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t *)&dcC);
 
             dplasma_zunmlq_param( parsec,
-                                  side[s], trans[t], &qrtree,
+                                  sides[s], trans[t], &qrtree,
                                   (parsec_tiled_matrix_t *)&dcA,
                                   (parsec_tiled_matrix_t *)&dcTS,
                                   (parsec_tiled_matrix_t *)&dcTT,
                                   (parsec_tiled_matrix_t *)&dcC);
 
-            if (side[s] == dplasmaLeft ) {
+            if (sides[s] == dplasmaLeft ) {
                 dplasma_zgemm( parsec, trans[t], dplasmaNoTrans,
                                -1., (parsec_tiled_matrix_t *)&dcQ,
                                     (parsec_tiled_matrix_t *)&dcC0,

--- a/tests/testing_zunmlq_systolic.c
+++ b/tests/testing_zunmlq_systolic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -147,8 +147,8 @@ int main(int argc, char ** argv)
 
     for (s=0; s<2; s++) {
 
-        int Cm = (side[s] == dplasmaLeft) ? N : M;
-        int Cn = (side[s] == dplasmaLeft) ? M : N;
+        int Cm = (sides[s] == dplasmaLeft) ? N : M;
+        int Cn = (sides[s] == dplasmaLeft) ? M : N;
         LDC = max(LDC, Cm);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
@@ -176,13 +176,13 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t *)&dcC);
 
             dplasma_zunmlq_param( parsec,
-                                  side[s], trans[t], &qrtree,
+                                  sides[s], trans[t], &qrtree,
                                   (parsec_tiled_matrix_t *)&dcA,
                                   (parsec_tiled_matrix_t *)&dcTS,
                                   (parsec_tiled_matrix_t *)&dcTT,
                                   (parsec_tiled_matrix_t *)&dcC);
 
-            if (side[s] == dplasmaLeft ) {
+            if (sides[s] == dplasmaLeft ) {
                 dplasma_zgemm( parsec, trans[t], dplasmaNoTrans,
                                -1., (parsec_tiled_matrix_t *)&dcQ,
                                     (parsec_tiled_matrix_t *)&dcC0,

--- a/tests/testing_zunmqr.c
+++ b/tests/testing_zunmqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -75,8 +75,8 @@ int main(int argc, char ** argv)
 
     for (s=0; s<2; s++) {
 
-        int Cm = (side[s] == dplasmaLeft) ? M : N;
-        int Cn = (side[s] == dplasmaLeft) ? N : M;
+        int Cm = (sides[s] == dplasmaLeft) ? M : N;
+        int Cn = (sides[s] == dplasmaLeft) ? N : M;
         LDC = max(LDC, Cm);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
@@ -103,12 +103,12 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t *)&dcC0,
                             (parsec_tiled_matrix_t *)&dcC);
 
-            dplasma_zunmqr( parsec, side[s], trans[t],
+            dplasma_zunmqr( parsec, sides[s], trans[t],
                             (parsec_tiled_matrix_t *)&dcA,
                             (parsec_tiled_matrix_t *)&dcT,
                             (parsec_tiled_matrix_t *)&dcC);
 
-            if (side[s] == dplasmaLeft ) {
+            if (sides[s] == dplasmaLeft ) {
                 dplasma_zgemm( parsec, trans[t], dplasmaNoTrans,
                                -1., (parsec_tiled_matrix_t *)&dcQ,
                                     (parsec_tiled_matrix_t *)&dcC0,

--- a/tests/testing_zunmqr_hqr.c
+++ b/tests/testing_zunmqr_hqr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -148,8 +148,8 @@ int main(int argc, char ** argv)
 
     for (s=0; s<2; s++) {
 
-        int Cm = (side[s] == dplasmaLeft) ? M : N;
-        int Cn = (side[s] == dplasmaLeft) ? N : M;
+        int Cm = (sides[s] == dplasmaLeft) ? M : N;
+        int Cn = (sides[s] == dplasmaLeft) ? N : M;
         LDC = max(LDC, Cm);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
@@ -177,13 +177,13 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t *)&dcC);
 
             dplasma_zunmqr_param( parsec,
-                                  side[s], trans[t], &qrtree,
+                                  sides[s], trans[t], &qrtree,
                                   (parsec_tiled_matrix_t *)&dcA,
                                   (parsec_tiled_matrix_t *)&dcTS,
                                   (parsec_tiled_matrix_t *)&dcTT,
                                   (parsec_tiled_matrix_t *)&dcC);
 
-            if (side[s] == dplasmaLeft ) {
+            if (sides[s] == dplasmaLeft ) {
                 dplasma_zgemm( parsec, trans[t], dplasmaNoTrans,
                                -1., (parsec_tiled_matrix_t *)&dcQ,
                                     (parsec_tiled_matrix_t *)&dcC0,

--- a/tests/testing_zunmqr_systolic.c
+++ b/tests/testing_zunmqr_systolic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2022 The University of Tennessee and The University
+ * Copyright (c) 2009-2024 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -147,8 +147,8 @@ int main(int argc, char ** argv)
 
     for (s=0; s<2; s++) {
 
-        int Cm = (side[s] == dplasmaLeft) ? M : N;
-        int Cn = (side[s] == dplasmaLeft) ? N : M;
+        int Cm = (sides[s] == dplasmaLeft) ? M : N;
+        int Cn = (sides[s] == dplasmaLeft) ? N : M;
         LDC = max(LDC, Cm);
 
         PASTE_CODE_ALLOCATE_MATRIX(dcC, 1,
@@ -176,13 +176,13 @@ int main(int argc, char ** argv)
                             (parsec_tiled_matrix_t *)&dcC);
 
             dplasma_zunmqr_param( parsec,
-                                  side[s], trans[t], &qrtree,
+                                  sides[s], trans[t], &qrtree,
                                   (parsec_tiled_matrix_t *)&dcA,
                                   (parsec_tiled_matrix_t *)&dcTS,
                                   (parsec_tiled_matrix_t *)&dcTT,
                                   (parsec_tiled_matrix_t *)&dcC);
 
-            if (side[s] == dplasmaLeft ) {
+            if (sides[s] == dplasmaLeft ) {
                 dplasma_zgemm( parsec, trans[t], dplasmaNoTrans,
                                -1., (parsec_tiled_matrix_t *)&dcQ,
                                     (parsec_tiled_matrix_t *)&dcC0,


### PR DESCRIPTION
also there was a name conflict between the uplo variable being an int in some testers, and an array of two ints in some other testers, I pluralized the arrays. 

fixes: #130 