### PR TITLE
bugix: use the proper HIPBLAS_OP_C when converting from dplasma_trans

### DIFF
--- a/src/zgemm_NN_gpu.jdf
+++ b/src/zgemm_NN_gpu.jdf
@@ -454,12 +454,10 @@ BODY [type=HIP]
              m, n, k, cAmb, cAnb, cBmb, cBnb, cCmb, cCnb);
 
     hipblasStatus_t status;
-    hipblasOperation_t opA = dplasmaNoTrans == transA? HIPBLAS_OP_N: HIPBLAS_OP_T;
-    hipblasOperation_t opB = dplasmaNoTrans == transB? HIPBLAS_OP_N: HIPBLAS_OP_T;
     dplasma_hip_handles_t *handles = parsec_info_get(&gpu_stream->infos, hip_handles_infokey);
     assert(NULL != handles);
     status = hipblasZgemm( handles->hipblas_handle,
-                           opA, opB,
+                           dplasma_hipblas_op(transA), dplasma_hipblas_op(transB),
                            tempmm, tempnn, tempkk,
                            &lalpha, A, ldam,
                                     B, ldbk,

--- a/src/zgemm_NN_summa.jdf
+++ b/src/zgemm_NN_summa.jdf
@@ -286,12 +286,10 @@ BODY [type=HIP
              (k==0)? creal(beta): 1.0, m, n, ldcm );
 
     hipblasStatus_t status;
-    hipblasOperation_t opA = dplasmaNoTrans == transA? HIPBLAS_OP_N: HIPBLAS_OP_T;
-    hipblasOperation_t opB = dplasmaNoTrans == transB? HIPBLAS_OP_N: HIPBLAS_OP_T;
     dplasma_hip_handles_t *handles = parsec_info_get(&gpu_stream->infos, hip_handles_infokey);
     assert(NULL != handles);
     status = hipblasZgemm( handles->hipblas_handle,
-                           opA, opB,
+                           dplasma_hipblas_op(transA), dplasma_hipblas_op(transB),
                            tempmm, tempnn, tempkk,
                            &lalpha, (hipblasDoubleComplex*)A, ldam,
                                     (hipblasDoubleComplex*)B, ldbk,

--- a/src/zgemm_NT_summa.jdf
+++ b/src/zgemm_NT_summa.jdf
@@ -286,12 +286,10 @@ BODY [type=HIP
              (k==0)? creal(beta): 1.0, m, n, ldcm );
 
     hipblasStatus_t status;
-    hipblasOperation_t opA = dplasmaNoTrans == transA? HIPBLAS_OP_N: HIPBLAS_OP_T;
-    hipblasOperation_t opB = dplasmaNoTrans == transB? HIPBLAS_OP_N: HIPBLAS_OP_T;
     dplasma_hip_handles_t *handles = parsec_info_get(&gpu_stream->infos, hip_handles_infokey);
     assert(NULL != handles);
     status = hipblasZgemm( handles->hipblas_handle,
-                           opA, opB,
+                           dplasma_hipblas_op(transA), dplasma_hipblas_op(transB),
                            tempmm, tempnn, tempkk,
                            &lalpha, (hipblasDoubleComplex*)A, ldam,
                                     (hipblasDoubleComplex*)B, ldbn,

--- a/src/zgemm_TN_summa.jdf
+++ b/src/zgemm_TN_summa.jdf
@@ -285,12 +285,10 @@ BODY [type=HIP
              (k==0)? creal(beta): 1.0, m, n, ldcm );
 
     hipblasStatus_t status;
-    hipblasOperation_t opA = dplasmaNoTrans == transA? HIPBLAS_OP_N: HIPBLAS_OP_T;
-    hipblasOperation_t opB = dplasmaNoTrans == transB? HIPBLAS_OP_N: HIPBLAS_OP_T;
     dplasma_hip_handles_t *handles = parsec_info_get(&gpu_stream->infos, hip_handles_infokey);
     assert(NULL != handles);
     status = hipblasZgemm( handles->hipblas_handle,
-                           opA, opB,
+                           dplasma_hipblas_op(transA), dplasma_hipblas_op(transB),
                            tempmm, tempnn, tempkk,
                            &lalpha, (hipblasDoubleComplex*)A, ldak,
                                     (hipblasDoubleComplex*)B, ldbk,

--- a/src/zgemm_TT_summa.jdf
+++ b/src/zgemm_TT_summa.jdf
@@ -288,12 +288,10 @@ BODY [type=HIP
              (k==0)? creal(beta): 1.0, m, n, ldcm );
 
     hipblasStatus_t status;
-    hipblasOperation_t opA = dplasmaNoTrans == transA? HIPBLAS_OP_N: HIPBLAS_OP_T;
-    hipblasOperation_t opB = dplasmaNoTrans == transB? HIPBLAS_OP_N: HIPBLAS_OP_T;
     dplasma_hip_handles_t *handles = parsec_info_get(&gpu_stream->infos, hip_handles_infokey);
     assert(NULL != handles);
     status = hipblasZgemm( handles->hipblas_handle,
-                           opA, opB,
+                           dplasma_hipblas_op(transA), dplasma_hipblas_op(transB),
                            tempmm, tempnn, tempkk,
                            &lalpha, (hipblasDoubleComplex*)A, ldak,
                                     (hipblasDoubleComplex*)B, ldbn,


### PR DESCRIPTION
bugix: use the proper HIPBLAS_OP_C when required converting from dplasma_trans constants

